### PR TITLE
feat: add dev-transform utilities and simplify Transform API

### DIFF
--- a/packages/@kamado-io/page-compiler/package.json
+++ b/packages/@kamado-io/page-compiler/package.json
@@ -18,6 +18,14 @@
 		"./format": {
 			"types": "./dist/format.d.ts",
 			"default": "./dist/format.js"
+		},
+		"./dev-transform/inject-to-head": {
+			"types": "./dist/dev-transform/inject-to-head.d.ts",
+			"default": "./dist/dev-transform/inject-to-head.js"
+		},
+		"./dev-transform/ssi-shim": {
+			"types": "./dist/dev-transform/ssi-shim.d.ts",
+			"default": "./dist/dev-transform/ssi-shim.js"
 		}
 	},
 	"scripts": {

--- a/packages/@kamado-io/page-compiler/src/dev-transform/inject-to-head.spec.ts
+++ b/packages/@kamado-io/page-compiler/src/dev-transform/inject-to-head.spec.ts
@@ -1,0 +1,225 @@
+import type { Context, TransformContext } from 'kamado/config';
+
+import { describe, expect, test } from 'vitest';
+
+import { injectToHead } from './inject-to-head.js';
+
+/**
+ * Create a mock TransformContext for testing
+ * @param overrides
+ */
+function createMockContext(overrides: Partial<TransformContext> = {}): TransformContext {
+	const mockContext: Context = {
+		mode: 'serve',
+		pkg: {},
+		dir: {
+			root: '/mock/root',
+			input: '/mock/input',
+			output: '/mock/output',
+		},
+		devServer: {
+			port: 3000,
+			host: 'localhost',
+			open: false,
+		},
+		compilers: [],
+	};
+
+	return {
+		path: '/test.html',
+		outputPath: '/mock/output/test.html',
+		isServe: true,
+		context: mockContext,
+		...overrides,
+	};
+}
+
+describe('injectToHead', () => {
+	describe('basic functionality', () => {
+		test('should inject content at head-end by default', async () => {
+			const transform = injectToHead({
+				content: '<script src="/dev.js"></script>',
+			});
+
+			const html = `<!DOCTYPE html>
+<html>
+<head>
+<title>Test</title>
+</head>
+<body>
+<p>Content</p>
+</body>
+</html>`;
+
+			const result = await transform.transform(html, createMockContext());
+			expect(result).toContain('<script src="/dev.js"></script>\n</head>');
+		});
+
+		test('should inject content at head-start when specified', async () => {
+			const transform = injectToHead({
+				content: '<meta name="viewport" content="width=device-width">',
+				position: 'head-start',
+			});
+
+			const html = `<!DOCTYPE html>
+<html>
+<head>
+<title>Test</title>
+</head>
+<body>
+<p>Content</p>
+</body>
+</html>`;
+
+			const result = await transform.transform(html, createMockContext());
+			expect(result).toContain(
+				'<head>\n<meta name="viewport" content="width=device-width">',
+			);
+		});
+
+		test('should handle ArrayBuffer input', async () => {
+			const transform = injectToHead({
+				content: '<script src="/dev.js"></script>',
+			});
+
+			const html = `<!DOCTYPE html>
+<html>
+<head>
+<title>Test</title>
+</head>
+<body>
+<p>Content</p>
+</body>
+</html>`;
+
+			const encoder = new TextEncoder();
+			const buffer = encoder.encode(html);
+
+			const result = await transform.transform(buffer, createMockContext());
+			expect(typeof result).toBe('string');
+			expect(result).toContain('<script src="/dev.js"></script>');
+		});
+	});
+
+	describe('dynamic content', () => {
+		test('should support function for dynamic content', async () => {
+			const transform = injectToHead({
+				content: () => '<meta name="timestamp" content="123456">',
+			});
+
+			const html = `<!DOCTYPE html>
+<html>
+<head>
+<title>Test</title>
+</head>
+<body>
+<p>Content</p>
+</body>
+</html>`;
+
+			const result = await transform.transform(html, createMockContext());
+			expect(result).toContain('<meta name="timestamp" content="123456">');
+		});
+
+		test('should support async function for dynamic content', async () => {
+			const transform = injectToHead({
+				content: async () => {
+					await new Promise((resolve) => setTimeout(resolve, 10));
+					return '<meta name="async" content="true">';
+				},
+			});
+
+			const html = `<!DOCTYPE html>
+<html>
+<head>
+<title>Test</title>
+</head>
+<body>
+<p>Content</p>
+</body>
+</html>`;
+
+			const result = await transform.transform(html, createMockContext());
+			expect(result).toContain('<meta name="async" content="true">');
+		});
+	});
+
+	describe('filter configuration', () => {
+		test('should have default filter for HTML files', () => {
+			const transform = injectToHead({
+				content: '<script src="/dev.js"></script>',
+			});
+
+			expect(transform.filter).toBeDefined();
+			expect(transform.filter?.include).toBe('**/*.html');
+		});
+
+		test('should allow custom filter configuration', () => {
+			const transform = injectToHead({
+				content: '<script src="/dev.js"></script>',
+				filter: {
+					include: '**/*.htm',
+					exclude: '**/admin/**',
+				},
+			});
+
+			expect(transform.filter?.include).toBe('**/*.htm');
+			expect(transform.filter?.exclude).toBe('**/admin/**');
+		});
+
+		test('should allow custom name', () => {
+			const transform = injectToHead({
+				content: '<script src="/dev.js"></script>',
+				name: 'custom-inject',
+			});
+
+			expect(transform.name).toBe('custom-inject');
+		});
+	});
+
+	describe('edge cases', () => {
+		test('should handle head tag with attributes', async () => {
+			const transform = injectToHead({
+				content: '<script src="/dev.js"></script>',
+			});
+
+			const html = `<!DOCTYPE html>
+<html>
+<head lang="en">
+<title>Test</title>
+</head>
+<body>
+<p>Content</p>
+</body>
+</html>`;
+
+			const result = await transform.transform(html, createMockContext());
+			expect(result).toContain('<script src="/dev.js"></script>\n</head>');
+		});
+
+		test('should handle multiple injections', async () => {
+			const transform1 = injectToHead({
+				content: '<script src="/first.js"></script>',
+			});
+			const transform2 = injectToHead({
+				content: '<script src="/second.js"></script>',
+			});
+
+			const html = `<!DOCTYPE html>
+<html>
+<head>
+<title>Test</title>
+</head>
+<body>
+<p>Content</p>
+</body>
+</html>`;
+
+			const result1 = await transform1.transform(html, createMockContext());
+			const result2 = await transform2.transform(result1, createMockContext());
+
+			expect(result2).toContain('<script src="/first.js"></script>');
+			expect(result2).toContain('<script src="/second.js"></script>');
+		});
+	});
+});

--- a/packages/@kamado-io/page-compiler/src/dev-transform/inject-to-head.ts
+++ b/packages/@kamado-io/page-compiler/src/dev-transform/inject-to-head.ts
@@ -1,0 +1,163 @@
+import type { ResponseTransform, TransformContext } from 'kamado/config';
+
+/**
+ * Position where content should be injected in the head element
+ */
+export type InjectPosition = 'head-start' | 'head-end';
+
+/**
+ * Options for injectToHead transform function
+ */
+export interface InjectToHeadTransformOptions {
+	/**
+	 * HTML content to inject into the head element
+	 * Can be a string or a function that returns a string (sync or async)
+	 * @example '<script src="/__dev-tools.js"></script>'
+	 * @example '<meta name="viewport" content="width=device-width, initial-scale=1">'
+	 */
+	readonly content: string | (() => string | Promise<string>);
+	/**
+	 * Position where the content should be injected
+	 * - 'head-start': Inject right after the opening <head> tag
+	 * - 'head-end': Inject right before the closing </head> tag (default)
+	 * @default 'head-end'
+	 */
+	readonly position?: InjectPosition;
+}
+
+/**
+ * Options for injectToHead utility (includes filter options)
+ */
+export interface InjectToHeadOptions extends InjectToHeadTransformOptions {
+	/**
+	 * Optional name for debugging
+	 * @default 'inject-to-head'
+	 */
+	readonly name?: string;
+	/**
+	 * Filter options to limit which files this transform applies to
+	 */
+	readonly filter?: {
+		/**
+		 * Glob pattern(s) to include
+		 * @default '**\/*.html'
+		 */
+		readonly include?: string | readonly string[];
+		/**
+		 * Glob pattern(s) to exclude
+		 */
+		readonly exclude?: string | readonly string[];
+	};
+}
+
+/**
+ * Create a transform function that injects content into the HTML head element
+ * This is the core transform function without filter configuration.
+ * Use this when you want to create custom ResponseTransform objects.
+ * @param options - Transform options
+ * @returns Transform function (content, context) => Promise<string | ArrayBuffer>
+ * @example Creating a custom ResponseTransform
+ * ```typescript
+ * import { createInjectToHeadTransform } from '@kamado-io/page-compiler/dev-transform/inject-to-head';
+ *
+ * export const config: UserConfig = {
+ *   devServer: {
+ *     transforms: [
+ *       {
+ *         name: 'my-custom-inject',
+ *         filter: { include: '**\/*.html' },
+ *         transform: createInjectToHeadTransform({
+ *           content: '<script src="/__dev.js"></script>',
+ *           position: 'head-end',
+ *         }),
+ *       },
+ *     ],
+ *   },
+ * };
+ * ```
+ */
+export function createInjectToHeadTransform(options: InjectToHeadTransformOptions) {
+	const position = options.position ?? 'head-end';
+
+	return async (
+		content: string | ArrayBuffer,
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		_context: TransformContext,
+	): Promise<string | ArrayBuffer> => {
+		// Decode ArrayBuffer to string if needed
+		let htmlContent: string;
+		if (typeof content === 'string') {
+			htmlContent = content;
+		} else {
+			const decoder = new TextDecoder('utf-8');
+			htmlContent = decoder.decode(content);
+		}
+
+		// Get content to inject (support function)
+		const injectContent =
+			typeof options.content === 'function'
+				? await Promise.resolve(options.content())
+				: options.content;
+
+		// Inject based on position
+		if (position === 'head-start') {
+			// Inject right after <head>
+			return htmlContent.replace(/(<head[^>]*>)/i, `$1\n${injectContent}`);
+		} else {
+			// Inject right before </head>
+			return htmlContent.replace(/(<\/head>)/i, `${injectContent}\n$1`);
+		}
+	};
+}
+
+/**
+ * Create a complete ResponseTransform that injects content into the HTML head element
+ * This is a convenience wrapper around createInjectToHeadTransform with filter configuration.
+ * Returns a ResponseTransform object with name and filter included, which can be used directly
+ * or customized via spread syntax.
+ * @param options - Configuration options including filters
+ * @returns ResponseTransform object for use in devServer.transforms
+ * @example Basic usage
+ * ```typescript
+ * import { injectToHead } from '@kamado-io/page-compiler/dev-transform/inject-to-head';
+ *
+ * export const config: UserConfig = {
+ *   devServer: {
+ *     transforms: [
+ *       injectToHead({
+ *         content: '<script src="/__dev-tools.js"></script>',
+ *         position: 'head-end',
+ *       }),
+ *     ],
+ *   },
+ * };
+ * ```
+ * @example Customizing with spread syntax
+ * ```typescript
+ * transforms: [
+ *   {
+ *     ...injectToHead({ content: '<script src="/dev.js"></script>' }),
+ *     name: 'my-custom-inject',
+ *   },
+ * ]
+ * ```
+ * @example Using a function for dynamic content
+ * ```typescript
+ * injectToHead({
+ *   content: () => `<meta name="build-time" content="${Date.now()}">`,
+ *   position: 'head-start',
+ * })
+ * ```
+ */
+export function injectToHead(options: InjectToHeadOptions): ResponseTransform {
+	const name = options.name ?? 'inject-to-head';
+
+	return {
+		name,
+		filter: {
+			include: options.filter?.include ?? '**/*.html',
+			exclude: options.filter?.exclude,
+		},
+		transform: createInjectToHeadTransform(options),
+	};
+}

--- a/packages/@kamado-io/page-compiler/src/dev-transform/ssi-shim.spec.ts
+++ b/packages/@kamado-io/page-compiler/src/dev-transform/ssi-shim.spec.ts
@@ -1,0 +1,686 @@
+import type { Context, TransformContext } from 'kamado/config';
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { createSSIShim } from './ssi-shim.js';
+
+/**
+ * Create a mock TransformContext for testing
+ * @param overrides
+ */
+function createMockContext(overrides: Partial<TransformContext> = {}): TransformContext {
+	const mockContext: Context = {
+		mode: 'serve',
+		pkg: {},
+		dir: {
+			root: '/mock/root',
+			input: '/mock/input',
+			output: '/mock/output',
+		},
+		devServer: {
+			port: 3000,
+			host: 'localhost',
+			open: false,
+		},
+		compilers: [],
+	};
+
+	return {
+		path: '/test.html',
+		outputPath: '/mock/output/test.html',
+		isServe: true,
+		context: mockContext,
+		...overrides,
+	};
+}
+
+describe('createSSIShim', () => {
+	const mockOutputDir = '/tmp/kamado-test-ssi';
+
+	beforeEach(async () => {
+		// Create test directory and files
+		await fs.mkdir(mockOutputDir, { recursive: true });
+		await fs.writeFile(
+			path.join(mockOutputDir, 'header.html'),
+			'<header>Site Header</header>',
+		);
+		await fs.writeFile(
+			path.join(mockOutputDir, 'footer.html'),
+			'<footer>Site Footer</footer>',
+		);
+	});
+
+	afterEach(async () => {
+		// Clean up test files
+		await fs.rm(mockOutputDir, { recursive: true, force: true });
+	});
+
+	describe('basic functionality', () => {
+		test('should replace SSI include directives with file content', async () => {
+			const transform = createSSIShim();
+
+			const html = `<!DOCTYPE html>
+<html>
+<head>
+<title>Test</title>
+</head>
+<body>
+<!--#include virtual="/header.html" -->
+<main>Content</main>
+<!--#include virtual="/footer.html" -->
+</body>
+</html>`;
+
+			const ctx = createMockContext({
+				context: {
+					...createMockContext().context,
+					dir: {
+						root: '/mock/root',
+						input: '/mock/input',
+						output: mockOutputDir,
+					},
+				},
+			});
+
+			const result = await transform.transform(html, ctx);
+
+			expect(result).toContain('<header>Site Header</header>');
+			expect(result).toContain('<footer>Site Footer</footer>');
+			expect(result).not.toContain('<!--#include virtual="/header.html" -->');
+			expect(result).not.toContain('<!--#include virtual="/footer.html" -->');
+		});
+
+		test('should handle ArrayBuffer input', async () => {
+			const transform = createSSIShim();
+
+			const html = `<!DOCTYPE html>
+<html>
+<body>
+<!--#include virtual="/header.html" -->
+</body>
+</html>`;
+
+			const encoder = new TextEncoder();
+			const buffer = encoder.encode(html);
+
+			const ctx = createMockContext({
+				context: {
+					...createMockContext().context,
+					dir: {
+						root: '/mock/root',
+						input: '/mock/input',
+						output: mockOutputDir,
+					},
+				},
+			});
+
+			const result = await transform.transform(buffer, ctx);
+
+			expect(typeof result).toBe('string');
+			expect(result).toContain('<header>Site Header</header>');
+		});
+
+		test('should handle include directives with extra whitespace', async () => {
+			const transform = createSSIShim();
+
+			const html = `<!--#include   virtual="/header.html"   -->`;
+
+			const ctx = createMockContext({
+				context: {
+					...createMockContext().context,
+					dir: {
+						root: '/mock/root',
+						input: '/mock/input',
+						output: mockOutputDir,
+					},
+				},
+			});
+
+			const result = await transform.transform(html, ctx);
+			expect(result).toContain('<header>Site Header</header>');
+		});
+	});
+
+	describe('error handling', () => {
+		test('should warn and replace with empty string when file not found', async () => {
+			const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+			const transform = createSSIShim();
+
+			const html = `<!--#include virtual="/nonexistent.html" -->`;
+
+			const ctx = createMockContext({
+				context: {
+					...createMockContext().context,
+					dir: {
+						root: '/mock/root',
+						input: '/mock/input',
+						output: mockOutputDir,
+					},
+				},
+			});
+
+			const result = await transform.transform(html, ctx);
+
+			expect(result).toBe('');
+			expect(consoleWarnSpy).toHaveBeenCalledWith(
+				'[ssi-shim] Failed to include /nonexistent.html:',
+				expect.any(String),
+			);
+
+			consoleWarnSpy.mockRestore();
+		});
+
+		test('should use custom error handler when provided', async () => {
+			const onError = vi.fn().mockReturnValue('<!-- Error: File not found -->');
+
+			const transform = createSSIShim({ onError });
+
+			const html = `<!--#include virtual="/nonexistent.html" -->`;
+
+			const ctx = createMockContext({
+				context: {
+					...createMockContext().context,
+					dir: {
+						root: '/mock/root',
+						input: '/mock/input',
+						output: mockOutputDir,
+					},
+				},
+			});
+
+			const result = await transform.transform(html, ctx);
+
+			expect(result).toBe('<!-- Error: File not found -->');
+			expect(onError).toHaveBeenCalledWith('/nonexistent.html', expect.any(Error));
+		});
+
+		test('should support async error handler', async () => {
+			const onError = vi.fn().mockImplementation(async (includePath: string) => {
+				await new Promise((resolve) => setTimeout(resolve, 10));
+				return `<!-- Failed to load ${includePath} -->`;
+			});
+
+			const transform = createSSIShim({ onError });
+
+			const html = `<!--#include virtual="/nonexistent.html" -->`;
+
+			const ctx = createMockContext({
+				context: {
+					...createMockContext().context,
+					dir: {
+						root: '/mock/root',
+						input: '/mock/input',
+						output: mockOutputDir,
+					},
+				},
+			});
+
+			const result = await transform.transform(html, ctx);
+
+			expect(result).toBe('<!-- Failed to load /nonexistent.html -->');
+			expect(onError).toHaveBeenCalledWith('/nonexistent.html', expect.any(Error));
+		});
+	});
+
+	describe('filter configuration', () => {
+		test('should have default filter for HTML files', () => {
+			const transform = createSSIShim();
+
+			expect(transform.filter).toBeDefined();
+			expect(transform.filter?.include).toBe('**/*.html');
+		});
+
+		test('should allow custom filter configuration', () => {
+			const transform = createSSIShim({
+				filter: {
+					include: ['**/*.html', '**/*.htm'],
+					exclude: '**/admin/**',
+				},
+			});
+
+			expect(transform.filter?.include).toEqual(['**/*.html', '**/*.htm']);
+			expect(transform.filter?.exclude).toBe('**/admin/**');
+		});
+
+		test('should allow custom name', () => {
+			const transform = createSSIShim({ name: 'custom-ssi' });
+
+			expect(transform.name).toBe('custom-ssi');
+		});
+	});
+
+	describe('real-world scenarios', () => {
+		test('should handle multiple includes in one file', async () => {
+			const transform = createSSIShim();
+
+			const html = `<!DOCTYPE html>
+<html>
+<head><title>Test</title></head>
+<body>
+<!--#include virtual="/header.html" -->
+<main>Main Content</main>
+<!--#include virtual="/footer.html" -->
+</body>
+</html>`;
+
+			const ctx = createMockContext({
+				context: {
+					...createMockContext().context,
+					dir: {
+						root: '/mock/root',
+						input: '/mock/input',
+						output: mockOutputDir,
+					},
+				},
+			});
+
+			const result = await transform.transform(html, ctx);
+
+			expect(result).toContain('<header>Site Header</header>');
+			expect(result).toContain('<main>Main Content</main>');
+			expect(result).toContain('<footer>Site Footer</footer>');
+		});
+
+		test('should handle includes with subdirectories', async () => {
+			const subDir = path.join(mockOutputDir, 'components');
+			await fs.mkdir(subDir, { recursive: true });
+			await fs.writeFile(path.join(subDir, 'nav.html'), '<nav>Navigation</nav>');
+
+			const transform = createSSIShim();
+
+			const html = `<!--#include virtual="/components/nav.html" -->`;
+
+			const ctx = createMockContext({
+				context: {
+					...createMockContext().context,
+					dir: {
+						root: '/mock/root',
+						input: '/mock/input',
+						output: mockOutputDir,
+					},
+				},
+			});
+
+			const result = await transform.transform(html, ctx);
+
+			expect(result).toContain('<nav>Navigation</nav>');
+		});
+	});
+
+	describe('dir option for simulating server document root', () => {
+		test('should resolve paths relative to specified dir', async () => {
+			// Setup: Create file in subdirectory
+			const includesDir = path.join(mockOutputDir, 'includes');
+			await fs.mkdir(includesDir, { recursive: true });
+			await fs.writeFile(
+				path.join(includesDir, 'header.html'),
+				'<header>Header with dir</header>',
+			);
+
+			// Simulate server document root path
+			const serverDocRoot = '/home/www/document_root/';
+			const transform = createSSIShim({ dir: serverDocRoot });
+
+			// Use absolute server path in SSI directive
+			const html = `<!--#include virtual="/home/www/document_root/includes/header.html" -->`;
+
+			const ctx = createMockContext({
+				context: {
+					...createMockContext().context,
+					dir: {
+						root: '/mock/root',
+						input: '/mock/input',
+						output: mockOutputDir,
+					},
+				},
+			});
+
+			const result = await transform.transform(html, ctx);
+
+			// Should read from {output}/includes/header.html
+			expect(result).toContain('<header>Header with dir</header>');
+		});
+
+		test('should handle multiple includes with dir option', async () => {
+			// Setup files
+			const includesDir = path.join(mockOutputDir, 'includes');
+			const partialsDir = path.join(mockOutputDir, 'partials');
+			await fs.mkdir(includesDir, { recursive: true });
+			await fs.mkdir(partialsDir, { recursive: true });
+			await fs.writeFile(
+				path.join(includesDir, 'header.html'),
+				'<header>Header</header>',
+			);
+			await fs.writeFile(
+				path.join(partialsDir, 'footer.html'),
+				'<footer>Footer</footer>',
+			);
+
+			const serverDocRoot = '/var/www/html/';
+			const transform = createSSIShim({ dir: serverDocRoot });
+
+			const html = `<!DOCTYPE html>
+<html>
+<body>
+<!--#include virtual="/var/www/html/includes/header.html" -->
+<main>Content</main>
+<!--#include virtual="/var/www/html/partials/footer.html" -->
+</body>
+</html>`;
+
+			const ctx = createMockContext({
+				context: {
+					...createMockContext().context,
+					dir: {
+						root: '/mock/root',
+						input: '/mock/input',
+						output: mockOutputDir,
+					},
+				},
+			});
+
+			const result = await transform.transform(html, ctx);
+
+			expect(result).toContain('<header>Header</header>');
+			expect(result).toContain('<footer>Footer</footer>');
+		});
+
+		test('should handle error when path is outside of dir', async () => {
+			const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+			const serverDocRoot = '/home/www/document_root/';
+			const transform = createSSIShim({ dir: serverDocRoot });
+
+			// Path outside of document root - file doesn't exist
+			const html = `<!--#include virtual="/var/this-definitely-does-not-exist/file.html" -->`;
+
+			const ctx = createMockContext({
+				context: {
+					...createMockContext().context,
+					dir: {
+						root: '/mock/root',
+						input: '/mock/input',
+						output: mockOutputDir,
+					},
+				},
+			});
+
+			const result = await transform.transform(html, ctx);
+
+			// Should fail and return empty (file doesn't exist)
+			expect(result).toBe('');
+			expect(consoleWarnSpy).toHaveBeenCalled();
+
+			consoleWarnSpy.mockRestore();
+		});
+	});
+
+	describe('common SSI use cases and patterns', () => {
+		test('should handle different file extensions (.txt, .shtml, .htm)', async () => {
+			// Create files with different extensions
+			await fs.writeFile(
+				path.join(mockOutputDir, 'script.txt'),
+				'<script>console.log("loaded");</script>',
+			);
+			await fs.writeFile(
+				path.join(mockOutputDir, 'nav.shtml'),
+				'<nav>Navigation Menu</nav>',
+			);
+			await fs.writeFile(
+				path.join(mockOutputDir, 'sidebar.htm'),
+				'<aside>Sidebar</aside>',
+			);
+
+			const transform = createSSIShim();
+
+			const html = `<!DOCTYPE html>
+<html>
+<head>
+<!--#include virtual="/script.txt" -->
+</head>
+<body>
+<!--#include virtual="/nav.shtml" -->
+<main>Content</main>
+<!--#include virtual="/sidebar.htm" -->
+</body>
+</html>`;
+
+			const ctx = createMockContext({
+				context: {
+					...createMockContext().context,
+					dir: {
+						root: '/mock/root',
+						input: '/mock/input',
+						output: mockOutputDir,
+					},
+				},
+			});
+
+			const result = await transform.transform(html, ctx);
+
+			expect(result).toContain('<script>console.log("loaded");</script>');
+			expect(result).toContain('<nav>Navigation Menu</nav>');
+			expect(result).toContain('<aside>Sidebar</aside>');
+		});
+
+		test('should handle empty files', async () => {
+			await fs.writeFile(path.join(mockOutputDir, 'empty.html'), '');
+
+			const transform = createSSIShim();
+
+			const html = `<div>Before</div>
+<!--#include virtual="/empty.html" -->
+<div>After</div>`;
+
+			const ctx = createMockContext({
+				context: {
+					...createMockContext().context,
+					dir: {
+						root: '/mock/root',
+						input: '/mock/input',
+						output: mockOutputDir,
+					},
+				},
+			});
+
+			const result = await transform.transform(html, ctx);
+
+			expect(result).toBe('<div>Before</div>\n\n<div>After</div>');
+		});
+
+		test('should handle typical page template pattern', async () => {
+			// Setup typical template structure
+			const includesDir = path.join(mockOutputDir, 'includes');
+			await fs.mkdir(includesDir, { recursive: true });
+			await fs.writeFile(
+				path.join(includesDir, 'header.html'),
+				'<header><h1>Site Title</h1></header>',
+			);
+			await fs.writeFile(
+				path.join(includesDir, 'navigation.html'),
+				'<nav><a href="/">Home</a></nav>',
+			);
+			await fs.writeFile(
+				path.join(includesDir, 'footer.html'),
+				'<footer>&copy; 2026</footer>',
+			);
+
+			const transform = createSSIShim();
+
+			const html = `<!DOCTYPE html>
+<html>
+<head>
+<title>My Page</title>
+</head>
+<body>
+<!--#include virtual="/includes/header.html" -->
+<!--#include virtual="/includes/navigation.html" -->
+<main>
+<h2>Page Content</h2>
+<p>This is the main content.</p>
+</main>
+<!--#include virtual="/includes/footer.html" -->
+</body>
+</html>`;
+
+			const ctx = createMockContext({
+				context: {
+					...createMockContext().context,
+					dir: {
+						root: '/mock/root',
+						input: '/mock/input',
+						output: mockOutputDir,
+					},
+				},
+			});
+
+			const result = await transform.transform(html, ctx);
+
+			expect(result).toContain('<header><h1>Site Title</h1></header>');
+			expect(result).toContain('<nav><a href="/">Home</a></nav>');
+			expect(result).toContain('<h2>Page Content</h2>');
+			expect(result).toContain('<footer>&copy; 2026</footer>');
+			// Verify order is maintained
+			expect(result.indexOf('<header>')).toBeLessThan(result.indexOf('<nav>'));
+			expect(result.indexOf('<nav>')).toBeLessThan(result.indexOf('<main>'));
+			expect(result.indexOf('<main>')).toBeLessThan(result.indexOf('<footer>'));
+		});
+
+		test('should handle filenames with special characters', async () => {
+			// Create file with spaces and dashes
+			await fs.writeFile(
+				path.join(mockOutputDir, 'my-include file.html'),
+				'<div>Special filename</div>',
+			);
+
+			const transform = createSSIShim();
+
+			const html = `<!--#include virtual="/my-include file.html" -->`;
+
+			const ctx = createMockContext({
+				context: {
+					...createMockContext().context,
+					dir: {
+						root: '/mock/root',
+						input: '/mock/input',
+						output: mockOutputDir,
+					},
+				},
+			});
+
+			const result = await transform.transform(html, ctx);
+
+			expect(result).toContain('<div>Special filename</div>');
+		});
+
+		test('should handle large file includes', async () => {
+			// Create a large file (100KB of content)
+			const largeContent = '<div>Line</div>\n'.repeat(5000);
+			await fs.writeFile(path.join(mockOutputDir, 'large.html'), largeContent);
+
+			const transform = createSSIShim();
+
+			const html = `<!--#include virtual="/large.html" -->`;
+
+			const ctx = createMockContext({
+				context: {
+					...createMockContext().context,
+					dir: {
+						root: '/mock/root',
+						input: '/mock/input',
+						output: mockOutputDir,
+					},
+				},
+			});
+
+			const result = await transform.transform(html, ctx);
+
+			expect(result).toBe(largeContent);
+		});
+
+		test('should preserve whitespace and formatting in included files', async () => {
+			const formattedContent = `    <div class="indented">
+        <p>Indented content</p>
+    </div>`;
+			await fs.writeFile(path.join(mockOutputDir, 'formatted.html'), formattedContent);
+
+			const transform = createSSIShim();
+
+			const html = `<div>
+<!--#include virtual="/formatted.html" -->
+</div>`;
+
+			const ctx = createMockContext({
+				context: {
+					...createMockContext().context,
+					dir: {
+						root: '/mock/root',
+						input: '/mock/input',
+						output: mockOutputDir,
+					},
+				},
+			});
+
+			const result = await transform.transform(html, ctx);
+
+			expect(result).toContain(formattedContent);
+		});
+
+		test('should handle includes at the very beginning and end of document', async () => {
+			await fs.writeFile(path.join(mockOutputDir, 'doctype.txt'), '<!DOCTYPE html>');
+			await fs.writeFile(path.join(mockOutputDir, 'closing.txt'), '</html>');
+
+			const transform = createSSIShim();
+
+			const html = `<!--#include virtual="/doctype.txt" -->
+<html>
+<body>Content</body>
+<!--#include virtual="/closing.txt" -->`;
+
+			const ctx = createMockContext({
+				context: {
+					...createMockContext().context,
+					dir: {
+						root: '/mock/root',
+						input: '/mock/input',
+						output: mockOutputDir,
+					},
+				},
+			});
+
+			const result = await transform.transform(html, ctx);
+
+			expect(result).toMatch(/^<!DOCTYPE html>/);
+			expect(result).toMatch(/<\/html>$/);
+		});
+
+		test('should handle consecutive includes without content between them', async () => {
+			await fs.writeFile(path.join(mockOutputDir, 'part1.html'), '<div>Part 1</div>');
+			await fs.writeFile(path.join(mockOutputDir, 'part2.html'), '<div>Part 2</div>');
+			await fs.writeFile(path.join(mockOutputDir, 'part3.html'), '<div>Part 3</div>');
+
+			const transform = createSSIShim();
+
+			const html = `<!--#include virtual="/part1.html" --><!--#include virtual="/part2.html" --><!--#include virtual="/part3.html" -->`;
+
+			const ctx = createMockContext({
+				context: {
+					...createMockContext().context,
+					dir: {
+						root: '/mock/root',
+						input: '/mock/input',
+						output: mockOutputDir,
+					},
+				},
+			});
+
+			const result = await transform.transform(html, ctx);
+
+			expect(result).toBe('<div>Part 1</div><div>Part 2</div><div>Part 3</div>');
+		});
+	});
+});

--- a/packages/@kamado-io/page-compiler/src/dev-transform/ssi-shim.ts
+++ b/packages/@kamado-io/page-compiler/src/dev-transform/ssi-shim.ts
@@ -1,0 +1,241 @@
+import type { ResponseTransform, TransformContext } from 'kamado/config';
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+/**
+ * Options for SSI shim transform function
+ */
+export interface SSIShimTransformOptions {
+	/**
+	 * Server document root path to simulate
+	 * When specified, virtual paths are treated as absolute paths from this document root,
+	 * and the relative portion is resolved against ctx.context.dir.output
+	 *
+	 * This is useful for simulating actual server document root behavior where SSI paths
+	 * reference the production server's absolute paths.
+	 * @example
+	 * If dir="/home/www/document_root/" and virtual="/home/www/document_root/includes/header.html"
+	 * then the actual file read will be: path.join(ctx.context.dir.output, "includes/header.html")
+	 * @example Without dir option
+	 * ```typescript
+	 * createSSIShim()
+	 * // <!--#include virtual="/header.html" --> reads from {output}/header.html
+	 * ```
+	 * @example With dir option
+	 * ```typescript
+	 * createSSIShim({ dir: '/home/www/document_root/' })
+	 * // <!--#include virtual="/home/www/document_root/includes/header.html" -->
+	 * // reads from {output}/includes/header.html
+	 * ```
+	 */
+	readonly dir?: string;
+	/**
+	 * Custom error handler for when included files cannot be read
+	 * @param includePath - The path that failed to load
+	 * @param error - The error that occurred
+	 * @returns Replacement content (empty string by default)
+	 */
+	readonly onError?: (includePath: string, error: unknown) => string | Promise<string>;
+}
+
+/**
+ * Options for SSI shim utility (includes filter options)
+ */
+export interface SSIShimOptions extends SSIShimTransformOptions {
+	/**
+	 * Optional name for debugging (used in error messages)
+	 * @default 'ssi-shim'
+	 */
+	readonly name?: string;
+	/**
+	 * Filter options to limit which files this transform applies to
+	 */
+	readonly filter?: {
+		/**
+		 * Glob pattern(s) to include
+		 * @default '**\/*.html'
+		 */
+		readonly include?: string | readonly string[];
+		/**
+		 * Glob pattern(s) to exclude
+		 */
+		readonly exclude?: string | readonly string[];
+	};
+}
+
+/**
+ * Create a transform function that implements pseudo Server Side Includes (SSI)
+ * This is the core transform function without filter configuration.
+ * Use this when you want to create custom ResponseTransform objects.
+ *
+ * Processes `<!--#include virtual="/path/to/file.html" -->` directives in HTML files
+ * and replaces them with the content of the referenced files.
+ * @param options - Transform options
+ * @param name
+ * @returns Transform function (content, context) => Promise<string | ArrayBuffer>
+ * @example Creating a custom ResponseTransform
+ * ```typescript
+ * import { createSSIShimTransform } from '@kamado-io/page-compiler/dev-transform/ssi-shim';
+ *
+ * export const config: UserConfig = {
+ *   devServer: {
+ *     transforms: [
+ *       {
+ *         name: 'my-ssi',
+ *         filter: { include: '**\/*.html' },
+ *         transform: createSSIShimTransform({
+ *           onError: (path) => `<!-- Failed: ${path} -->`,
+ *         }),
+ *       },
+ *     ],
+ *   },
+ * };
+ * ```
+ */
+export function createSSIShimTransform(
+	options: SSIShimTransformOptions = {},
+	name = 'ssi-shim',
+) {
+	return async (
+		content: string | ArrayBuffer,
+		ctx: TransformContext,
+	): Promise<string | ArrayBuffer> => {
+		// Decode ArrayBuffer to string if needed
+		let htmlContent: string;
+		if (typeof content === 'string') {
+			htmlContent = content;
+		} else {
+			const decoder = new TextDecoder('utf-8');
+			htmlContent = decoder.decode(content);
+		}
+
+		// Match SSI include directives: <!--#include virtual="/path/to/file.html" -->
+		const includeRegex = /<!--#include\s+virtual="([^"]+)"\s*-->/g;
+		let result = htmlContent;
+
+		// Process each include directive
+		for (const match of htmlContent.matchAll(includeRegex)) {
+			const includePath = match[1];
+			const fullMatch = match[0];
+
+			// Skip if includePath is not captured
+			if (!includePath) {
+				continue;
+			}
+
+			// Resolve the file path
+			let filePath: string;
+			if (options.dir) {
+				// When dir is specified, treat includePath as absolute path from document root
+				// Calculate relative path and resolve against output directory
+				const relativePath = path.relative(options.dir, includePath);
+				filePath = path.join(ctx.context.dir.output, relativePath);
+			} else {
+				// Default behavior: resolve relative to output directory
+				filePath = path.resolve(ctx.context.dir.output, includePath.replace(/^\//, ''));
+			}
+
+			try {
+				// Read the included file
+				const includeContent = await fs.readFile(filePath, 'utf8');
+				result = result.replace(fullMatch, includeContent);
+			} catch (error) {
+				// Handle error (custom handler or default)
+				const errorContent = options.onError
+					? await Promise.resolve(options.onError(includePath, error))
+					: '';
+
+				// Log warning if no custom error handler
+				if (!options.onError) {
+					// eslint-disable-next-line no-console
+					console.warn(
+						`[${name}] Failed to include ${includePath}:`,
+						error instanceof Error ? error.message : String(error),
+					);
+				}
+
+				result = result.replace(fullMatch, errorContent);
+			}
+		}
+
+		return result;
+	};
+}
+
+/**
+ * Create a complete ResponseTransform that implements pseudo Server Side Includes (SSI)
+ * This is a convenience wrapper around createSSIShimTransform with filter configuration.
+ * Returns a ResponseTransform object with name and filter included, which can be used directly
+ * or customized via spread syntax.
+ *
+ * Processes `<!--#include virtual="/path/to/file.html" -->` directives in HTML files
+ * and replaces them with the content of the referenced files.
+ * @param options - Configuration options including filters
+ * @returns ResponseTransform object for use in devServer.transforms
+ * @example Basic usage
+ * ```typescript
+ * import { createSSIShim } from '@kamado-io/page-compiler/dev-transform/ssi-shim';
+ *
+ * export const config: UserConfig = {
+ *   devServer: {
+ *     transforms: [
+ *       createSSIShim(),
+ *     ],
+ *   },
+ * };
+ * ```
+ * @example Customizing with spread syntax
+ * ```typescript
+ * transforms: [
+ *   {
+ *     ...createSSIShim(),
+ *     name: 'my-ssi',
+ *     filter: { include: ['**\/*.html', '**\/*.htm'] },
+ *   },
+ * ]
+ * ```
+ * @example With custom error handling
+ * ```typescript
+ * createSSIShim({
+ *   onError: (path, error) => {
+ *     console.error(`Failed to include ${path}:`, error);
+ *     return `<!-- Failed to include: ${path} -->`;
+ *   },
+ * })
+ * ```
+ * @example Simulating server document root
+ * ```typescript
+ * createSSIShim({
+ *   dir: '/home/www/document_root/',
+ * })
+ * // In HTML: <!--#include virtual="/home/www/document_root/includes/header.html" -->
+ * // Will read from: {output}/includes/header.html
+ * ```
+ * @example In HTML files
+ * ```html
+ * <!DOCTYPE html>
+ * <html>
+ *   <head>
+ *     <title>My Page</title>
+ *   </head>
+ *   <body>
+ *     <!--#include virtual="/header.html" -->
+ *     <main>Content here</main>
+ *     <!--#include virtual="/footer.html" -->
+ *   </body>
+ * </html>
+ * ```
+ */
+export function createSSIShim(options: SSIShimOptions = {}): ResponseTransform {
+	const name = options.name ?? 'ssi-shim';
+
+	return {
+		name,
+		filter: {
+			include: options.filter?.include ?? '**/*.html',
+			exclude: options.filter?.exclude,
+		},
+		transform: createSSIShimTransform(options, name),
+	};
+}

--- a/packages/kamado/README.md
+++ b/packages/kamado/README.md
@@ -299,7 +299,6 @@ export const config: UserConfig = {
 				name: 'inject-dev-script',
 				filter: {
 					include: '**/*.html',
-					contentType: 'text/html',
 				},
 				transform: (content) => {
 					if (typeof content !== 'string') {
@@ -352,7 +351,7 @@ export const config: UserConfig = {
 			{
 				name: 'css-source-comment',
 				filter: {
-					contentType: 'text/css',
+					include: '**/*.css',
 				},
 				transform: (content, ctx) => {
 					if (typeof content !== 'string') {
@@ -376,7 +375,6 @@ interface ResponseTransform {
 	filter?: {
 		include?: string | string[]; // Glob patterns to include
 		exclude?: string | string[]; // Glob patterns to exclude
-		contentType?: string | string[]; // Content-Type filter (supports wildcards)
 	};
 	transform: (
 		content: string | ArrayBuffer,
@@ -386,7 +384,6 @@ interface ResponseTransform {
 
 interface TransformContext {
 	path: string; // Request path
-	contentType: string | undefined; // Response Content-Type
 	inputPath?: string; // Original input file path (if available)
 	outputPath: string; // Output file path
 	isServe: boolean; // Always true in dev server
@@ -398,7 +395,6 @@ interface TransformContext {
 
 - `include`: Glob pattern(s) to match request paths (e.g., `'**/*.html'`, `['**/*.css', '**/*.js']`)
 - `exclude`: Glob pattern(s) to exclude (e.g., `'**/_*.html'` to skip files starting with `_`)
-- `contentType`: Content-Type filter(s) with wildcard support (e.g., `'text/html'`, `'text/*'`, `['text/html', 'application/json']`)
 
 **Important Notes:**
 

--- a/packages/kamado/src/config/types.ts
+++ b/packages/kamado/src/config/types.ts
@@ -98,10 +98,6 @@ export interface TransformContext {
 	 */
 	readonly path: string;
 	/**
-	 * Response Content-Type header
-	 */
-	readonly contentType: string | undefined;
-	/**
 	 * Original input file path (if available from compiler)
 	 */
 	readonly inputPath?: string;
@@ -142,12 +138,6 @@ export interface ResponseTransform {
 		 * @example '**\/_*.html'
 		 */
 		readonly exclude?: string | readonly string[];
-		/**
-		 * Content-Type filter
-		 * Supports wildcard patterns like 'text/*'
-		 * @example ['text/html', 'text/css']
-		 */
-		readonly contentType?: string | readonly string[];
 	};
 	/**
 	 * Transform function to modify response content

--- a/packages/kamado/src/server/route.ts
+++ b/packages/kamado/src/server/route.ts
@@ -66,7 +66,6 @@ export async function setRoute(app: Hono, context: Context, options: RouteOption
 				content,
 				{
 					path: requestFilePath,
-					contentType: ctx.res.headers.get('Content-Type') ?? undefined,
 					inputPath,
 					outputPath,
 					isServe: true,

--- a/packages/kamado/src/server/transform.ts
+++ b/packages/kamado/src/server/transform.ts
@@ -96,28 +96,5 @@ function shouldApplyTransform(
 		}
 	}
 
-	// Content-Type filtering (with wildcard support)
-	if (filter.contentType && context.contentType) {
-		const contentTypes = Array.isArray(filter.contentType)
-			? filter.contentType
-			: [filter.contentType];
-
-		const matches = contentTypes.some((ct) => {
-			// Support wildcard patterns like "text/*"
-			if (ct.includes('*')) {
-				const regex = new RegExp(
-					'^' + ct.replaceAll('*', '.*').replaceAll('/', '\\/') + '$',
-				);
-				return regex.test(context.contentType!);
-			}
-			// Exact match or substring match
-			return context.contentType!.includes(ct);
-		});
-
-		if (!matches) {
-			return false;
-		}
-	}
-
 	return true;
 }


### PR DESCRIPTION
## Summary

This PR adds development server transform utilities and simplifies the Transform API by removing contentType filtering.

## Changes

### 1. Simplify Transform API (kamado)
- Remove `contentType` filter from `ResponseTransform` interface
- Simplify to use only path-based filtering (glob patterns)
- Remove contentType checking logic from transform execution
- Update documentation and tests

**Rationale**: Content-Type filtering creates unnecessary coupling to server implementation details. Path-based filtering is sufficient and more reliable.

### 2. Add dev-transform utilities (page-compiler)
- **`injectToHead`**: Utility to inject content into HTML head element
  - Supports `head-start` and `head-end` positions
  - Supports dynamic content via functions
- **`createSSIShim`**: Pseudo Server Side Includes (SSI) implementation
  - Processes `<!--#include virtual="/path" -->` directives
  - Supports document root simulation via `dir` option
  - Custom error handling support
  - 22 comprehensive test cases covering various SSI use cases

Both utilities use path-based filtering only.

## Test Results
✅ All 150 tests passing
✅ Build successful
✅ Lint passing

## Breaking Changes
None - contentType filter was added in a previous PR but not yet released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the dev-server `ResponseTransform` contract (removing `contentType`) and transform matching behavior, which can alter when transforms run for existing users; new utilities also perform filesystem reads during development.
> 
> **Overview**
> Adds new dev-server transform utilities to `@kamado-io/page-compiler`: `injectToHead` (injects static or dynamic content at `head-start`/`head-end`) and `createSSIShim` (replaces `<!--#include virtual="..." -->` directives by reading included files from the output dir, with optional simulated document root + custom error handling). These are exported via package `exports`, documented in the page-compiler README, and covered by new Vitest suites.
> 
> Simplifies Kamado's Response Transform API by **removing `contentType` from `TransformContext` and `ResponseTransform.filter`**, deleting content-type matching logic in `applyTransforms`, and updating server route context construction, docs, and tests to use **path/glob-based filtering only**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 629b48bc5e7608a7f828d899fa7ee5b34fa0966d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->