### PR TITLE
feat(kamado): add proxy support for dev server

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -3,6 +3,7 @@
 	"ignorePaths": ["**/CHANGELOG.md"],
 	"words": [
 		//
-		"kamado"
+		"kamado",
+		"unstub"
 	]
 }

--- a/packages/kamado/ARCHITECTURE.ja.md
+++ b/packages/kamado/ARCHITECTURE.ja.md
@@ -513,7 +513,7 @@ export interface TransformContext<M extends MetaData> {
 // プロキシルール設定
 export interface ProxyRule {
 	readonly target: string; // プロキシ先のターゲットURL
-	readonly pathRewrite?: (path: string) => string; // プロキシ前にパスを書き換え
+	readonly pathRewrite?: (path: string) => string | Promise<string>; // プロキシ前にパスを書き換え
 	readonly changeOrigin?: boolean; // Origin/Hostヘッダーを変更（デフォルト: false）
 }
 

--- a/packages/kamado/ARCHITECTURE.ja.md
+++ b/packages/kamado/ARCHITECTURE.ja.md
@@ -66,7 +66,7 @@ export interface Context<M extends MetaData> extends Config<M> {
 
 - **`cli.ts`**: CLI のエントリポイント。`@d-zero/roar` を使用してコマンドを処理します。
 - **`builder/`**: 静的ビルド（`kamado build`）の実行ロジック。
-- **`server/`**: 開発サーバー（`kamado server`）のロジック。Hono を使用。
+- **`server/`**: 開発サーバー（`kamado server`）のロジック。Hono を使用。プロキシ転送（`proxy.ts`）、レスポンス変換（`transform.ts`）、ルートハンドリング（`route.ts`）を含む。
 - **`compiler/`**: コンパイラ・プラグインのインターフェースと、機能マップの管理。
 - **`config/`**: 設定ファイルのロードとマージ、デフォルト値の定義、`defineConfig()`ヘルパーの提供。
 - **`data/`**: コンパイル対象ファイルのリストアップ、アセットグループの管理。
@@ -198,9 +198,15 @@ graph TD
     A[CLI: server] --> B[config のロード]
     B --> B2[Context の作成 mode='serve']
     B2 --> C[compilableFileMap & コンパイラの作成]
-    C --> C2[Hono サーバーの起動]
+    C --> C1{proxy が設定<br>されているか?}
+    C1 -- Yes --> C1a[プロキシルートを登録]
+    C1a --> C2[Hono サーバーの起動]
+    C1 -- No --> C2
     C2 --> D[ブラウザからのリクエスト受領]
-    D --> E[URL からローカルパスを計算]
+    D --> D1{プロキシのパス<br>プレフィックスに一致?}
+    D1 -- Yes --> D2[ターゲットサーバーへ転送]
+    D2 --> D3[プロキシレスポンスを返却]
+    D1 -- No --> E[URL からローカルパスを計算]
     E --> F{compilableFileMap に<br>存在するか?}
     F -- Yes --> H[オンメモリでコンパイル実行]
     H --> I[レスポンス変換を適用]
@@ -496,6 +502,54 @@ export interface TransformContext<M extends MetaData> {
 - **モックデータ**: APIレスポンスにテストデータを挿入
 
 **注意**: このAPIは意図的に開発専用です。本番用の変換には、page compilerのTransform Pipeline（`transforms`オプションに`manipulateDOM()`、`characterEntities()`、`prettier()`などのtransform factoryを設定）またはビルド時処理を使用してください。
+
+### プロキシAPI
+
+プロキシAPIは、設定されたパスプレフィックスに一致するリクエストを外部サーバーへ転送します。`src/server/proxy.ts`に実装され、`src/server/app.ts`でHonoアプリに統合されています。
+
+#### アーキテクチャ
+
+```typescript
+// プロキシルール設定
+export interface ProxyRule {
+	readonly target: string; // プロキシ先のターゲットURL
+	readonly pathRewrite?: (path: string) => string; // プロキシ前にパスを書き換え
+	readonly changeOrigin?: boolean; // Origin/Hostヘッダーを変更（デフォルト: false）
+}
+
+// 設定: Record<pathPrefix, ProxyRule | string>
+// 例: { '/api': 'https://backend.example.com' }
+```
+
+#### 実行フロー
+
+1. **ルート登録**: `setProxyRoutes()`は`app.ts`内で`setRoute()`**より前に**呼ばれるため、プロキシルートがファイルサーブルートよりも優先される
+2. **パスソート**: エントリはパスプレフィックスの長さでソートされ（長い順）、特定のルートが一般的なルートよりも先にマッチするようになっている
+3. **ルール正規化**: 文字列省略形の値は`normalizeRule()`により`ProxyRule`オブジェクトに正規化される
+4. **リクエスト転送**: ネイティブ`fetch()`を使用し、ヘッダーを手動管理。リクエストヘッダーは転送され、`changeOrigin: true`の場合は`Host`/`Origin`がオプションで書き換えられる
+5. **ボディ処理**: リクエストボディはボディを持つメソッド（POST、PUT、PATCH、DELETE）でストリーミングされる。GETとHEADリクエストにはボディがない
+6. **エラーハンドリング**: プロキシ失敗時は`502 Bad Gateway`レスポンスが返され、エラーはコンソールにログ出力される
+
+#### 実装の詳細
+
+**場所**: `src/server/proxy.ts`
+
+主要な関数:
+
+- `setProxyRoutes(app, proxyConfig)`: Honoアプリにプロキシルートを登録
+- `normalizeRule(rule)`: 文字列省略形を`ProxyRule`オブジェクトに変換
+- `hasBody(method)`: HTTPメソッドがリクエストボディを持つかどうかを判定
+
+**統合**: `src/server/app.ts`
+
+プロキシルートは条件付きで登録される — `context.devServer.proxy`が定義されている場合のみ。`${pathPrefix}/*`と`${pathPrefix}`の両パターンが登録され、ネストされたリクエストと完全一致リクエストの両方を処理する。
+
+#### 設計上の判断
+
+- **ネイティブ`fetch()`**: HTTPプロキシライブラリではなくランタイム組み込みの`fetch()`を使用し、依存関係を最小限に抑えている
+- **`redirect: 'manual'`**: ターゲットサーバーからのリダイレクトレスポンスを自動追従せず、そのまま保持する
+- **`duplex: 'half'`**: Node.jsの`fetch()`実装でストリーミングリクエストボディを有効にする
+- **レスポンス変換なし**: プロキシレスポンスはレスポンス変換パイプラインを通さず、そのまま返却される
 
 ---
 

--- a/packages/kamado/ARCHITECTURE.md
+++ b/packages/kamado/ARCHITECTURE.md
@@ -66,7 +66,7 @@ Key directories under `packages/kamado/src` and their roles:
 
 - **`cli.ts`**: CLI entry point. Processes commands using `@d-zero/roar`.
 - **`builder/`**: Execution logic for static builds (`kamado build`).
-- **`server/`**: Logic for the development server (`kamado server`) using Hono.
+- **`server/`**: Logic for the development server (`kamado server`) using Hono. Includes proxy forwarding (`proxy.ts`), response transforms (`transform.ts`), and route handling (`route.ts`).
 - **`compiler/`**: Management of compiler plugin interfaces and the function map.
 - **`config/`**: Loading and merging configuration files, defining default values, and providing the `defineConfig()` helper.
 - **`data/`**: Listing files for compilation and managing asset groups.
@@ -198,9 +198,15 @@ graph TD
     A[CLI: server] --> B[Load config]
     B --> B2[Create Context with mode='serve']
     B2 --> C[Create compilableFileMap & compiler]
-    C --> C2[Start Hono server]
+    C --> C1{proxy configured?}
+    C1 -- Yes --> C1a[Register proxy routes]
+    C1a --> C2[Start Hono server]
+    C1 -- No --> C2
     C2 --> D[Receive browser request]
-    D --> E[Calculate local path from URL]
+    D --> D1{Matches proxy<br>path prefix?}
+    D1 -- Yes --> D2[Forward to target server]
+    D2 --> D3[Return proxy response]
+    D1 -- No --> E[Calculate local path from URL]
     E --> F{Exists in<br>compilableFileMap?}
     F -- Yes --> H[Perform in-memory compilation]
     H --> I[Apply Response Transforms]
@@ -496,6 +502,54 @@ A helper function `respondWithTransform()` consolidates the transform applicatio
 - **Mock Data**: Inject test data into API responses
 
 **Note**: This API is intentionally development-only. For production transformations, use the page compiler's Transform Pipeline (configure `transforms` option with transform factories like `manipulateDOM()`, `characterEntities()`, `prettier()`, etc.) or build-time processing.
+
+### Proxy API
+
+The Proxy API forwards requests matching configured path prefixes to external servers during development. It is implemented in `src/server/proxy.ts` and integrated into the Hono app in `src/server/app.ts`.
+
+#### Architecture
+
+```typescript
+// Proxy rule configuration
+export interface ProxyRule {
+	readonly target: string; // Target URL to proxy to
+	readonly pathRewrite?: (path: string) => string; // Rewrite path before proxying
+	readonly changeOrigin?: boolean; // Change Origin/Host headers (default: false)
+}
+
+// Configuration: Record<pathPrefix, ProxyRule | string>
+// e.g., { '/api': 'https://backend.example.com' }
+```
+
+#### Execution Flow
+
+1. **Route Registration**: `setProxyRoutes()` is called **before** `setRoute()` in `app.ts`, so proxy routes take priority over file-serving routes
+2. **Path Sorting**: Entries are sorted by path prefix length (longest first) to ensure specific routes match before general ones
+3. **Rule Normalization**: String shorthand values are normalized into `ProxyRule` objects via `normalizeRule()`
+4. **Request Forwarding**: Uses native `fetch()` with manual header management. Request headers are forwarded; `Host`/`Origin` are optionally rewritten when `changeOrigin: true`
+5. **Body Handling**: Request bodies are streamed for methods that carry a body (POST, PUT, PATCH, DELETE). GET and HEAD requests have no body
+6. **Error Handling**: On proxy failure, a `502 Bad Gateway` response is returned and the error is logged to the console
+
+#### Implementation Details
+
+**Location**: `src/server/proxy.ts`
+
+Key functions:
+
+- `setProxyRoutes(app, proxyConfig)`: Registers proxy routes on the Hono app
+- `normalizeRule(rule)`: Converts string shorthand to `ProxyRule` object
+- `hasBody(method)`: Determines if an HTTP method carries a request body
+
+**Integration**: `src/server/app.ts`
+
+Proxy routes are registered conditionally — only when `context.devServer.proxy` is defined. Both `${pathPrefix}/*` and `${pathPrefix}` patterns are registered to handle nested and exact-match requests.
+
+#### Design Decisions
+
+- **Native `fetch()`**: Uses the runtime's built-in `fetch()` rather than an HTTP proxy library, keeping the dependency footprint minimal
+- **`redirect: 'manual'`**: Preserves redirect responses from the target server instead of following them automatically
+- **`duplex: 'half'`**: Enables streaming request bodies in Node.js `fetch()` implementation
+- **No response transforms**: Proxy responses are returned as-is without passing through the Response Transform pipeline
 
 ---
 

--- a/packages/kamado/ARCHITECTURE.md
+++ b/packages/kamado/ARCHITECTURE.md
@@ -513,7 +513,7 @@ The Proxy API forwards requests matching configured path prefixes to external se
 // Proxy rule configuration
 export interface ProxyRule {
 	readonly target: string; // Target URL to proxy to
-	readonly pathRewrite?: (path: string) => string; // Rewrite path before proxying
+	readonly pathRewrite?: (path: string) => string | Promise<string>; // Rewrite path before proxying
 	readonly changeOrigin?: boolean; // Change Origin/Host headers (default: false)
 }
 

--- a/packages/kamado/README.ja.md
+++ b/packages/kamado/README.ja.md
@@ -473,7 +473,7 @@ export default defineConfig({
 ```typescript
 interface ProxyRule {
 	target: string; // プロキシ先のターゲットURL
-	pathRewrite?: (path: string) => string; // プロキシ前にパスを書き換える関数
+	pathRewrite?: (path: string) => string | Promise<string>; // プロキシ前にパスを書き換える関数
 	changeOrigin?: boolean; // Origin/Hostヘッダーをターゲットに合わせて変更するか（デフォルト: false）
 }
 ```

--- a/packages/kamado/README.ja.md
+++ b/packages/kamado/README.ja.md
@@ -474,7 +474,7 @@ export default defineConfig({
 interface ProxyRule {
 	target: string; // プロキシ先のターゲットURL
 	pathRewrite?: (path: string) => string; // プロキシ前にパスを書き換える関数
-	changeOrigin?: boolean; // Origin/Hostヘッダーをターゲットに合わせて変更するか（デフォルト: true）
+	changeOrigin?: boolean; // Origin/Hostヘッダーをターゲットに合わせて変更するか（デフォルト: false）
 }
 ```
 
@@ -490,7 +490,7 @@ interface ProxyRule {
 - プロキシルートはファイルサーブルートよりも先にマッチするため、プロキシパスはローカルファイルよりも優先されます
 - 長いパスプレフィックスが先にマッチします（例: `/api/v2` は `/api` よりも優先）
 - クエリ文字列は保持されターゲットに転送されます
-- リクエストヘッダーは転送されます（`changeOrigin`が`true`の場合、`Host`と`Origin`が調整されます）
+- リクエストヘッダーは転送されます。ターゲットサーバーが `Host` ヘッダーを検証している場合は `changeOrigin: true` を設定すると `Host` と `Origin` ヘッダーがターゲットに合わせて書き換えられます
 - プロキシ失敗時は`502 Bad Gateway`レスポンスが返されます
 - 開発サーバーモード（`kamado server`）でのみ適用され、ビルド時には適用されません
 

--- a/packages/kamado/README.ja.md
+++ b/packages/kamado/README.ja.md
@@ -144,6 +144,7 @@ export default defineConfig({
 - `devServer.open`: 起動時にブラウザを自動で開くか（デフォルト: `false`）
 - `devServer.startPath`: サーバー起動時にブラウザで開くカスタムパス（オプション、例: `'__tmpl/'`）
 - `devServer.transforms`: 開発時にレスポンスを変換する関数の配列（オプション、[レスポンス変換API](#レスポンス変換api)を参照）
+- `devServer.proxy`: 開発時に外部サーバーへリクエストを転送するプロキシルール（オプション、[プロキシAPI](#プロキシapi)を参照）
 
 #### コンパイラ設定
 
@@ -424,6 +425,73 @@ interface TransformContext<M extends MetaData> {
 - 静的ファイル（コンパイル対象外のファイル）は通常`ArrayBuffer`として渡されるため、テキストとして処理する場合は必ずデコードしてください
 - 変換関数のエラーはログに記録されますが、サーバーを停止させません（元のコンテンツが返されます）
 - 変換は配列の順序で実行されます
+- 開発サーバーモード（`kamado server`）でのみ適用され、ビルド時には適用されません
+
+#### プロキシAPI
+
+プロキシAPIを使用すると、開発サーバーモード時にリクエストを外部サーバーに転送できます。静的サイトから別ドメインのAPIにAJAXリクエストを送る場合に、ローカル開発時のCORS問題を回避できます。
+
+**主な特徴:**
+
+- **開発時のみ**: プロキシは`serve`モードでのみ適用され、ビルド時には適用されません
+- **全HTTPメソッド対応**: GET、POST、PUT、DELETE、PATCHなどすべてのメソッドをサポート
+- **ストリーミング**: レスポンスはバッファリングせずにストリーミングされます
+- **パスリライト**: リクエストパスを転送前に書き換え可能
+- **簡易・詳細形式**: シンプルな場合は文字列、詳細な制御が必要な場合はオブジェクトを使用
+
+**設定例:**
+
+```typescript
+import { defineConfig } from 'kamado/config';
+
+export default defineConfig({
+	devServer: {
+		port: 3000,
+		proxy: {
+			// 簡易形式: 文字列でターゲットURLを指定 — /api/* をターゲットに転送
+			'/api': 'https://backend.example.com',
+
+			// 詳細形式: パスリライト付きのオブジェクト形式
+			'/api/v2': {
+				target: 'https://api-v2.example.com',
+				// /api/v2/users → /users にリライト
+				pathRewrite: (path) => path.replace(/^\/api\/v2/, ''),
+				changeOrigin: true,
+			},
+		},
+	},
+});
+```
+
+上記の設定では:
+
+- `GET /api/data` → `GET https://backend.example.com/api/data`
+- `POST /api/v2/users` → `POST https://api-v2.example.com/users`（パスがリライトされます）
+
+**ProxyRuleインターフェース:**
+
+```typescript
+interface ProxyRule {
+	target: string; // プロキシ先のターゲットURL
+	pathRewrite?: (path: string) => string; // プロキシ前にパスを書き換える関数
+	changeOrigin?: boolean; // Origin/Hostヘッダーをターゲットに合わせて変更するか（デフォルト: true）
+}
+```
+
+**プロキシ設定:**
+
+`proxy`オプションはレコード型で、以下の形式です:
+
+- **キー**: マッチするパスプレフィックス（例: `'/api'`）
+- **値**: ターゲットURL文字列（簡易形式）または`ProxyRule`オブジェクト
+
+**重要な注意事項:**
+
+- プロキシルートはファイルサーブルートよりも先にマッチするため、プロキシパスはローカルファイルよりも優先されます
+- 長いパスプレフィックスが先にマッチします（例: `/api/v2` は `/api` よりも優先）
+- クエリ文字列は保持されターゲットに転送されます
+- リクエストヘッダーは転送されます（`changeOrigin`が`true`の場合、`Host`と`Origin`が調整されます）
+- プロキシ失敗時は`502 Bad Gateway`レスポンスが返されます
 - 開発サーバーモード（`kamado server`）でのみ適用され、ビルド時には適用されません
 
 ### CLIコマンド

--- a/packages/kamado/README.md
+++ b/packages/kamado/README.md
@@ -474,7 +474,7 @@ With the configuration above:
 interface ProxyRule {
 	target: string; // Target URL to proxy to
 	pathRewrite?: (path: string) => string; // Rewrite path before proxying
-	changeOrigin?: boolean; // Change Origin/Host headers to match target (default: true)
+	changeOrigin?: boolean; // Change Origin/Host headers to match target (default: false)
 }
 ```
 
@@ -490,7 +490,7 @@ The `proxy` option is a record where:
 - Proxy routes are matched before file-serving routes, so proxy paths take priority over local files
 - Longer path prefixes are matched first (e.g., `/api/v2` takes priority over `/api`)
 - Query strings are preserved and forwarded to the target
-- Request headers are forwarded (with `Host` and `Origin` adjusted when `changeOrigin` is `true`)
+- Request headers are forwarded. Set `changeOrigin: true` to rewrite `Host` and `Origin` headers to match the target (useful when the target server validates the `Host` header)
 - On proxy failure, a `502 Bad Gateway` response is returned
 - Only applied in development server mode (`kamado server`), not during builds
 

--- a/packages/kamado/README.md
+++ b/packages/kamado/README.md
@@ -144,6 +144,7 @@ export default defineConfig({
 - `devServer.open`: Whether to automatically open the browser on startup (default: `false`)
 - `devServer.startPath`: Custom path to open in the browser when starting the server (optional, e.g., `'__tmpl/'`)
 - `devServer.transforms`: Array of response transformation functions that modify responses during development (optional, see [Response Transform API](#response-transform-api))
+- `devServer.proxy`: Proxy rules for forwarding requests to external servers during development (optional, see [Proxy API](#proxy-api))
 
 #### Compiler Settings
 
@@ -424,6 +425,73 @@ interface TransformContext<M extends MetaData> {
 - Static files (non-compiled files) are typically passed as `ArrayBuffer`, so always decode them if you need to process as text
 - Errors in transform functions are logged but don't break the server (original content is returned)
 - Transforms are executed in array order
+- Only applied in development server mode (`kamado server`), not during builds
+
+#### Proxy API
+
+The Proxy API allows you to forward requests to external servers during development. This is useful when your static site makes AJAX requests to APIs on different domains, avoiding CORS issues during local development.
+
+**Key Features:**
+
+- **Development-only**: Proxy only applies in `serve` mode, not during builds
+- **All HTTP methods**: Supports GET, POST, PUT, DELETE, PATCH, and other methods
+- **Streaming**: Responses are streamed without buffering
+- **Path rewriting**: Optionally rewrite request paths before forwarding
+- **Simple and advanced forms**: Use a string shorthand for simple cases or an object for full control
+
+**Configuration:**
+
+```typescript
+import { defineConfig } from 'kamado/config';
+
+export default defineConfig({
+	devServer: {
+		port: 3000,
+		proxy: {
+			// Simple: string shorthand — forward /api/* to the target
+			'/api': 'https://backend.example.com',
+
+			// Advanced: object form with path rewriting
+			'/api/v2': {
+				target: 'https://api-v2.example.com',
+				// Rewrite /api/v2/users → /users
+				pathRewrite: (path) => path.replace(/^\/api\/v2/, ''),
+				changeOrigin: true,
+			},
+		},
+	},
+});
+```
+
+With the configuration above:
+
+- `GET /api/data` → `GET https://backend.example.com/api/data`
+- `POST /api/v2/users` → `POST https://api-v2.example.com/users` (path rewritten)
+
+**ProxyRule Interface:**
+
+```typescript
+interface ProxyRule {
+	target: string; // Target URL to proxy to
+	pathRewrite?: (path: string) => string; // Rewrite path before proxying
+	changeOrigin?: boolean; // Change Origin/Host headers to match target (default: true)
+}
+```
+
+**Proxy Configuration:**
+
+The `proxy` option is a record where:
+
+- **Key**: Path prefix to match (e.g., `'/api'`)
+- **Value**: A target URL string (shorthand) or a `ProxyRule` object
+
+**Important Notes:**
+
+- Proxy routes are matched before file-serving routes, so proxy paths take priority over local files
+- Longer path prefixes are matched first (e.g., `/api/v2` takes priority over `/api`)
+- Query strings are preserved and forwarded to the target
+- Request headers are forwarded (with `Host` and `Origin` adjusted when `changeOrigin` is `true`)
+- On proxy failure, a `502 Bad Gateway` response is returned
 - Only applied in development server mode (`kamado server`), not during builds
 
 ### CLI Commands

--- a/packages/kamado/README.md
+++ b/packages/kamado/README.md
@@ -473,7 +473,7 @@ With the configuration above:
 ```typescript
 interface ProxyRule {
 	target: string; // Target URL to proxy to
-	pathRewrite?: (path: string) => string; // Rewrite path before proxying
+	pathRewrite?: (path: string) => string | Promise<string>; // Rewrite path before proxying
 	changeOrigin?: boolean; // Change Origin/Host headers to match target (default: false)
 }
 ```

--- a/packages/kamado/src/config/merge-config.ts
+++ b/packages/kamado/src/config/merge-config.ts
@@ -35,6 +35,7 @@ export async function mergeConfig<M extends MetaData>(
 			host: 'localhost',
 			startPath: undefined,
 			transforms: [],
+			proxy: undefined,
 			...config.devServer,
 		},
 		pageList: config.pageList,

--- a/packages/kamado/src/config/types.ts
+++ b/packages/kamado/src/config/types.ts
@@ -173,7 +173,7 @@ export interface ProxyRule {
 	 * Rewrite the path before proxying
 	 * @example (path) => path.replace(/^\/api/, '')
 	 */
-	readonly pathRewrite?: (path: string) => string;
+	readonly pathRewrite?: (path: string) => string | Promise<string>;
 	/**
 	 * Whether to change the Origin/Host headers to match the target.
 	 * Set to `true` if the target server validates the `Host` header.

--- a/packages/kamado/src/config/types.ts
+++ b/packages/kamado/src/config/types.ts
@@ -175,8 +175,18 @@ export interface ProxyRule {
 	 */
 	readonly pathRewrite?: (path: string) => string;
 	/**
-	 * Whether to change the Origin/Host headers to match the target
-	 * @default true
+	 * Whether to change the Origin/Host headers to match the target.
+	 * Set to `true` if the target server validates the `Host` header.
+	 * @default false
+	 * @example
+	 * ```typescript
+	 * proxy: {
+	 *   '/api': {
+	 *     target: 'https://api.example.com',
+	 *     changeOrigin: true,
+	 *   },
+	 * }
+	 * ```
 	 */
 	readonly changeOrigin?: boolean;
 }

--- a/packages/kamado/src/config/types.ts
+++ b/packages/kamado/src/config/types.ts
@@ -161,6 +161,27 @@ export interface Transform<M extends MetaData = MetaData> {
 }
 
 /**
+ * Proxy rule configuration for dev server
+ */
+export interface ProxyRule {
+	/**
+	 * Target URL to proxy to
+	 * @example 'https://api.example.com'
+	 */
+	readonly target: string;
+	/**
+	 * Rewrite the path before proxying
+	 * @example (path) => path.replace(/^\/api/, '')
+	 */
+	readonly pathRewrite?: (path: string) => string;
+	/**
+	 * Whether to change the Origin/Host headers to match the target
+	 * @default true
+	 */
+	readonly changeOrigin?: boolean;
+}
+
+/**
  * Development server configuration
  */
 export interface DevServerConfig<M extends MetaData> {
@@ -202,6 +223,22 @@ export interface DevServerConfig<M extends MetaData> {
 	 * ```
 	 */
 	readonly transforms?: readonly Transform<M>[];
+	/**
+	 * Proxy rules for dev server.
+	 * Key is the path prefix to match (e.g., '/api').
+	 * Value is a ProxyRule object or a target URL string (shorthand).
+	 * @example
+	 * ```typescript
+	 * proxy: {
+	 *   '/api': 'https://backend.example.com',
+	 *   '/api/v2': {
+	 *     target: 'https://api-v2.example.com',
+	 *     pathRewrite: (path) => path.replace(/^\/api\/v2/, ''),
+	 *   },
+	 * }
+	 * ```
+	 */
+	readonly proxy?: Readonly<Record<string, ProxyRule | string>>;
 }
 
 /**

--- a/packages/kamado/src/server/app.ts
+++ b/packages/kamado/src/server/app.ts
@@ -8,6 +8,7 @@ import c from 'ansi-colors';
 import { Hono } from 'hono';
 import open from 'open';
 
+import { setProxyRoutes } from './proxy.js';
 import { setRoute } from './route.js';
 
 /**
@@ -36,6 +37,10 @@ export async function start<M extends MetaData>(
 
 	const app = new Hono();
 
+	if (context.devServer.proxy) {
+		setProxyRoutes(app, context.devServer.proxy);
+	}
+
 	await setRoute({ app, context }, { verbose: options?.verbose });
 
 	const server = serve({
@@ -60,12 +65,21 @@ export async function start<M extends MetaData>(
 	const relDocumentRoot =
 		'.' + path.sep + path.relative(process.cwd(), context.dir.input);
 
+	const proxyLines = context.devServer.proxy
+		? Object.entries(context.devServer.proxy)
+				.map(([prefix, rule]) => {
+					const target = typeof rule === 'string' ? rule : rule.target;
+					return `  ${c.blue('Proxy')}: ${prefix} → ${c.bold.gray(target)}`;
+				})
+				.join('\n')
+		: '';
+
 	process.stdout.write(`
   ${c.bold.greenBright('Kamado Dev Server: Ignition🔥')}
 
   ${c.blue('Location')}: ${c.bold(location)}
   ${c.blue('DocumentRoot')}: ${c.bold.gray(relDocumentRoot)}
-`);
+${proxyLines ? `${proxyLines}\n` : ''}`);
 
 	if (context.devServer.open) {
 		await open(location);

--- a/packages/kamado/src/server/proxy.spec.ts
+++ b/packages/kamado/src/server/proxy.spec.ts
@@ -1,0 +1,111 @@
+import { Hono } from 'hono';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { setProxyRoutes } from './proxy.js';
+
+describe('setProxyRoutes', () => {
+	beforeEach(() => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(new Response('upstream', { status: 200 })),
+		);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	test('fetches to the target specified by string shorthand', async () => {
+		const app = new Hono();
+		setProxyRoutes(app, { '/api': 'https://backend.example.com' });
+
+		await app.request('/api/users');
+
+		const fetchMock = vi.mocked(fetch);
+		expect(fetchMock).toHaveBeenCalledOnce();
+		expect(fetchMock.mock.calls[0]![0]).toBe('https://backend.example.com/api/users');
+	});
+
+	test('longer path prefix matches first (/api/v2 takes priority over /api)', async () => {
+		const app = new Hono();
+		setProxyRoutes(app, {
+			'/api': 'https://v1.example.com',
+			'/api/v2': 'https://v2.example.com',
+		});
+
+		await app.request('/api/v2/users');
+
+		expect(vi.mocked(fetch).mock.calls[0]![0]).toContain('v2.example.com');
+	});
+
+	test('fetches to the URL with pathRewrite applied', async () => {
+		const app = new Hono();
+		setProxyRoutes(app, {
+			'/api': {
+				target: 'https://backend.example.com',
+				pathRewrite: (p) => p.replace(/^\/api/, ''),
+			},
+		});
+
+		await app.request('/api/users');
+
+		expect(vi.mocked(fetch).mock.calls[0]![0]).toBe('https://backend.example.com/users');
+	});
+
+	test('rewrites Host/Origin headers to target when changeOrigin is true', async () => {
+		const app = new Hono();
+		setProxyRoutes(app, {
+			'/api': { target: 'https://backend.example.com', changeOrigin: true },
+		});
+
+		await app.request('/api/data');
+
+		const [, init] = vi.mocked(fetch).mock.calls[0]! as [string, RequestInit];
+		const headers = init.headers as Headers;
+		expect(headers.get('host')).toBe('backend.example.com');
+		expect(headers.get('origin')).toBe('https://backend.example.com');
+	});
+
+	test('does not rewrite Host header when changeOrigin is false (default)', async () => {
+		const app = new Hono();
+		setProxyRoutes(app, {
+			'/api': { target: 'https://backend.example.com' },
+		});
+
+		await app.request('/api/data');
+
+		const [, init] = vi.mocked(fetch).mock.calls[0]! as [string, RequestInit];
+		const headers = init.headers as Headers;
+		expect(headers.get('host')).not.toBe('backend.example.com');
+	});
+
+	test('returns 502 when fetch fails', async () => {
+		vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+		const app = new Hono();
+		setProxyRoutes(app, { '/api': 'https://backend.example.com' });
+
+		const res = await app.request('/api/data');
+
+		expect(res.status).toBe(502);
+	});
+
+	test('does not pass body to fetch for GET requests', async () => {
+		const app = new Hono();
+		setProxyRoutes(app, { '/api': 'https://backend.example.com' });
+
+		await app.request('/api/data', { method: 'GET' });
+
+		const [, init] = vi.mocked(fetch).mock.calls[0]! as [string, RequestInit];
+		expect(init.body).toBeUndefined();
+	});
+
+	test('does not pass body to fetch for HEAD requests', async () => {
+		const app = new Hono();
+		setProxyRoutes(app, { '/api': 'https://backend.example.com' });
+
+		await app.request('/api/data', { method: 'HEAD' });
+
+		const [, init] = vi.mocked(fetch).mock.calls[0]! as [string, RequestInit];
+		expect(init.body).toBeUndefined();
+	});
+});

--- a/packages/kamado/src/server/proxy.spec.ts
+++ b/packages/kamado/src/server/proxy.spec.ts
@@ -1,7 +1,33 @@
 import { Hono } from 'hono';
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 
-import { setProxyRoutes } from './proxy.js';
+import { hasBody, normalizeRule, setProxyRoutes } from './proxy.js';
+
+describe('normalizeRule', () => {
+	test('converts string to ProxyRule object', () => {
+		expect(normalizeRule('https://example.com')).toEqual({
+			target: 'https://example.com',
+		});
+	});
+
+	test('returns ProxyRule object as-is', () => {
+		const rule = { target: 'https://example.com', changeOrigin: true };
+		expect(normalizeRule(rule)).toBe(rule);
+	});
+});
+
+describe('hasBody', () => {
+	test.each([
+		['GET', false],
+		['HEAD', false],
+		['POST', true],
+		['PUT', true],
+		['PATCH', true],
+		['DELETE', true],
+	])('%s → %s', (method, expected) => {
+		expect(hasBody(method)).toBe(expected);
+	});
+});
 
 describe('setProxyRoutes', () => {
 	beforeEach(() => {
@@ -35,7 +61,10 @@ describe('setProxyRoutes', () => {
 
 		await app.request('/api/v2/users');
 
-		expect(vi.mocked(fetch).mock.calls[0]![0]).toContain('v2.example.com');
+		expect(vi.mocked(fetch)).toHaveBeenCalledOnce();
+		expect(vi.mocked(fetch).mock.calls[0]![0]).toBe(
+			'https://v2.example.com/api/v2/users',
+		);
 	});
 
 	test('fetches to the URL with pathRewrite applied', async () => {
@@ -77,6 +106,7 @@ describe('setProxyRoutes', () => {
 		const [, init] = vi.mocked(fetch).mock.calls[0]! as [string, RequestInit];
 		const headers = init.headers as Headers;
 		expect(headers.get('host')).not.toBe('backend.example.com');
+		expect(headers.get('origin')).toBeNull();
 	});
 
 	test('returns 502 when fetch fails', async () => {
@@ -107,5 +137,42 @@ describe('setProxyRoutes', () => {
 
 		const [, init] = vi.mocked(fetch).mock.calls[0]! as [string, RequestInit];
 		expect(init.body).toBeUndefined();
+	});
+
+	test('passes body to fetch for POST requests', async () => {
+		const app = new Hono();
+		setProxyRoutes(app, { '/api': 'https://backend.example.com' });
+
+		const body = JSON.stringify({ name: 'test' });
+		await app.request('/api/data', {
+			method: 'POST',
+			body,
+			headers: { 'Content-Type': 'application/json' },
+		});
+
+		const [, init] = vi.mocked(fetch).mock.calls[0]! as [string, RequestInit];
+		expect(init.method).toBe('POST');
+		expect(init.body).toBeDefined();
+	});
+
+	test('preserves query strings when forwarding to target', async () => {
+		const app = new Hono();
+		setProxyRoutes(app, { '/api': 'https://backend.example.com' });
+
+		await app.request('/api/users?page=2&limit=10');
+
+		expect(vi.mocked(fetch).mock.calls[0]![0]).toBe(
+			'https://backend.example.com/api/users?page=2&limit=10',
+		);
+	});
+
+	test('matches the prefix path exactly without trailing slash', async () => {
+		const app = new Hono();
+		setProxyRoutes(app, { '/api': 'https://backend.example.com' });
+
+		await app.request('/api');
+
+		expect(vi.mocked(fetch)).toHaveBeenCalledOnce();
+		expect(vi.mocked(fetch).mock.calls[0]![0]).toBe('https://backend.example.com/api');
 	});
 });

--- a/packages/kamado/src/server/proxy.spec.ts
+++ b/packages/kamado/src/server/proxy.spec.ts
@@ -81,6 +81,20 @@ describe('setProxyRoutes', () => {
 		expect(vi.mocked(fetch).mock.calls[0]![0]).toBe('https://backend.example.com/users');
 	});
 
+	test('fetches to the URL with async pathRewrite applied', async () => {
+		const app = new Hono();
+		setProxyRoutes(app, {
+			'/api': {
+				target: 'https://backend.example.com',
+				pathRewrite: (p) => Promise.resolve(p.replace(/^\/api/, '')),
+			},
+		});
+
+		await app.request('/api/users');
+
+		expect(vi.mocked(fetch).mock.calls[0]![0]).toBe('https://backend.example.com/users');
+	});
+
 	test('rewrites Host/Origin headers to target when changeOrigin is true', async () => {
 		const app = new Hono();
 		setProxyRoutes(app, {

--- a/packages/kamado/src/server/proxy.ts
+++ b/packages/kamado/src/server/proxy.ts
@@ -8,7 +8,7 @@ import c from 'ansi-colors';
  * @param rule - Proxy rule to normalize
  * @returns Normalized ProxyRule object
  */
-function normalizeRule(rule: ProxyRule | string): ProxyRule {
+export function normalizeRule(rule: ProxyRule | string): ProxyRule {
 	if (typeof rule === 'string') {
 		return { target: rule };
 	}
@@ -20,7 +20,7 @@ function normalizeRule(rule: ProxyRule | string): ProxyRule {
  * @param method - HTTP method
  * @returns Whether the method has a body
  */
-function hasBody(method: string): boolean {
+export function hasBody(method: string): boolean {
 	return !['GET', 'HEAD'].includes(method.toUpperCase());
 }
 

--- a/packages/kamado/src/server/proxy.ts
+++ b/packages/kamado/src/server/proxy.ts
@@ -1,0 +1,85 @@
+import type { ProxyRule } from '../config/types.js';
+import type { Context, Hono } from 'hono';
+
+import c from 'ansi-colors';
+
+/**
+ * Normalize a proxy rule (string shorthand or ProxyRule object)
+ * @param rule - Proxy rule to normalize
+ * @returns Normalized ProxyRule object
+ */
+function normalizeRule(rule: ProxyRule | string): ProxyRule {
+	if (typeof rule === 'string') {
+		return { target: rule };
+	}
+	return rule;
+}
+
+/**
+ * Check if the HTTP method typically carries a request body
+ * @param method - HTTP method
+ * @returns Whether the method has a body
+ */
+function hasBody(method: string): boolean {
+	return !['GET', 'HEAD'].includes(method.toUpperCase());
+}
+
+/**
+ * Register proxy routes on the Hono app.
+ * Must be called BEFORE setRoute() so proxy routes take priority.
+ * @param app - Hono application instance
+ * @param proxyConfig - Proxy configuration record
+ */
+export function setProxyRoutes(
+	app: Hono,
+	proxyConfig: Readonly<Record<string, ProxyRule | string>>,
+): void {
+	const sortedEntries = Object.entries(proxyConfig).toSorted(([a], [b]) => b.length - a.length);
+
+	for (const [pathPrefix, rawRule] of sortedEntries) {
+		const rule = normalizeRule(rawRule);
+		const targetUrl = new URL(rule.target);
+		const changeOrigin = rule.changeOrigin !== false;
+
+		const handler = async (ctx: Context) => {
+			const requestUrl = new URL(ctx.req.url);
+			const originalPath = requestUrl.pathname;
+			const rewrittenPath = rule.pathRewrite ? rule.pathRewrite(originalPath) : originalPath;
+
+			const proxyUrl = new URL(rewrittenPath, targetUrl);
+			proxyUrl.search = requestUrl.search;
+
+			const headers = new Headers(ctx.req.raw.headers);
+			if (changeOrigin) {
+				headers.set('host', targetUrl.host);
+				headers.set('origin', targetUrl.origin);
+			}
+
+			try {
+				const proxyResponse = await fetch(proxyUrl.toString(), {
+					method: ctx.req.method,
+					headers,
+					body: hasBody(ctx.req.method) ? ctx.req.raw.body : undefined,
+					// @ts-expect-error -- Node.js fetch supports duplex for streaming request bodies
+					duplex: hasBody(ctx.req.method) ? 'half' : undefined,
+					redirect: 'manual',
+				});
+
+				return new Response(proxyResponse.body, {
+					status: proxyResponse.status,
+					statusText: proxyResponse.statusText,
+					headers: proxyResponse.headers,
+				});
+			} catch (error) {
+				const message =
+					error instanceof Error ? error.message : 'Unknown proxy error';
+				// eslint-disable-next-line no-console
+				console.error(c.red(`  Proxy error [${pathPrefix} → ${rule.target}]: ${message}`));
+				return ctx.text('Proxy error', 502);
+			}
+		};
+
+		app.all(`${pathPrefix}/*`, handler);
+		app.all(pathPrefix, handler);
+	}
+}

--- a/packages/kamado/src/server/proxy.ts
+++ b/packages/kamado/src/server/proxy.ts
@@ -39,7 +39,7 @@ export function setProxyRoutes(
 	for (const [pathPrefix, rawRule] of sortedEntries) {
 		const rule = normalizeRule(rawRule);
 		const targetUrl = new URL(rule.target);
-		const changeOrigin = rule.changeOrigin !== false;
+		const changeOrigin = rule.changeOrigin === true;
 
 		const handler = async (ctx: Context) => {
 			const requestUrl = new URL(ctx.req.url);
@@ -55,6 +55,7 @@ export function setProxyRoutes(
 				headers.set('origin', targetUrl.origin);
 			}
 
+	
 			try {
 				const proxyResponse = await fetch(proxyUrl.toString(), {
 					method: ctx.req.method,

--- a/packages/kamado/src/server/proxy.ts
+++ b/packages/kamado/src/server/proxy.ts
@@ -34,7 +34,9 @@ export function setProxyRoutes(
 	app: Hono,
 	proxyConfig: Readonly<Record<string, ProxyRule | string>>,
 ): void {
-	const sortedEntries = Object.entries(proxyConfig).toSorted(([a], [b]) => b.length - a.length);
+	const sortedEntries = Object.entries(proxyConfig).toSorted(
+		([a], [b]) => b.length - a.length,
+	);
 
 	for (const [pathPrefix, rawRule] of sortedEntries) {
 		const rule = normalizeRule(rawRule);
@@ -44,7 +46,9 @@ export function setProxyRoutes(
 		const handler = async (ctx: Context) => {
 			const requestUrl = new URL(ctx.req.url);
 			const originalPath = requestUrl.pathname;
-			const rewrittenPath = rule.pathRewrite ? rule.pathRewrite(originalPath) : originalPath;
+			const rewrittenPath = rule.pathRewrite
+				? rule.pathRewrite(originalPath)
+				: originalPath;
 
 			const proxyUrl = new URL(rewrittenPath, targetUrl);
 			proxyUrl.search = requestUrl.search;
@@ -55,7 +59,6 @@ export function setProxyRoutes(
 				headers.set('origin', targetUrl.origin);
 			}
 
-	
 			try {
 				const proxyResponse = await fetch(proxyUrl.toString(), {
 					method: ctx.req.method,
@@ -72,10 +75,11 @@ export function setProxyRoutes(
 					headers: proxyResponse.headers,
 				});
 			} catch (error) {
-				const message =
-					error instanceof Error ? error.message : 'Unknown proxy error';
+				const message = error instanceof Error ? error.message : 'Unknown proxy error';
 				// eslint-disable-next-line no-console
-				console.error(c.red(`  Proxy error [${pathPrefix} → ${rule.target}]: ${message}`));
+				console.error(
+					c.red(`  Proxy error [${pathPrefix} → ${rule.target}]: ${message}`),
+				);
 				return ctx.text('Proxy error', 502);
 			}
 		};

--- a/packages/kamado/src/server/proxy.ts
+++ b/packages/kamado/src/server/proxy.ts
@@ -47,7 +47,7 @@ export function setProxyRoutes(
 			const requestUrl = new URL(ctx.req.url);
 			const originalPath = requestUrl.pathname;
 			const rewrittenPath = rule.pathRewrite
-				? rule.pathRewrite(originalPath)
+				? await rule.pathRewrite(originalPath)
 				: originalPath;
 
 			const proxyUrl = new URL(rewrittenPath, targetUrl);


### PR DESCRIPTION
## Summary
- Add `devServer.proxy` option to forward requests to external servers during development, avoiding CORS issues for AJAX calls
- Support string shorthand (`'/api': 'https://example.com'`) and object form with `pathRewrite` / `changeOrigin`
- Longer path prefixes are matched first to prevent routing conflicts
- Add comprehensive Proxy API documentation to README.md and README.ja.md

## Test plan
- [ ] Configure proxy and verify request forwarding
- [ ] Verify `pathRewrite` / `changeOrigin` behavior
- [ ] Run `yarn build` and confirm no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)