### PR TITLE
feat: add inline sourcemap option to script and style compilers

### DIFF
--- a/packages/@kamado-io/script-compiler/README.md
+++ b/packages/@kamado-io/script-compiler/README.md
@@ -35,7 +35,7 @@ export default defineConfig({
 - `alias`: Map of path aliases (key is alias name, value is actual path)
 - `minifier`: Whether to enable minification
 - `banner`: Banner configuration (can specify CreateBanner function or string)
-- `sourcemap`: Emit an inline source map (data URI appended as `//# sourceMappingURL=...`). Default: `false`. esbuild adjusts mappings to account for the banner automatically.
+- `sourcemap`: Emit an inline source map (data URI appended as `//# sourceMappingURL=...`). Accepts `boolean | 'onServer'`. When set to `'onServer'`, the source map is emitted only while kamado runs in serve mode (`context.mode === 'serve'`). Default: `false`. esbuild adjusts mappings to account for the banner automatically.
 
 ## License
 

--- a/packages/@kamado-io/script-compiler/README.md
+++ b/packages/@kamado-io/script-compiler/README.md
@@ -35,6 +35,7 @@ export default defineConfig({
 - `alias`: Map of path aliases (key is alias name, value is actual path)
 - `minifier`: Whether to enable minification
 - `banner`: Banner configuration (can specify CreateBanner function or string)
+- `sourcemap`: Emit an inline source map (data URI appended as `//# sourceMappingURL=...`). Default: `false`. esbuild adjusts mappings to account for the banner automatically.
 
 ## License
 

--- a/packages/@kamado-io/script-compiler/README.md
+++ b/packages/@kamado-io/script-compiler/README.md
@@ -35,7 +35,7 @@ export default defineConfig({
 - `alias`: Map of path aliases (key is alias name, value is actual path)
 - `minifier`: Whether to enable minification
 - `banner`: Banner configuration (can specify CreateBanner function or string)
-- `sourcemap`: Emit an inline source map (data URI appended as `//# sourceMappingURL=...`). Accepts `boolean | 'onServer'`. When set to `'onServer'`, the source map is emitted only while kamado runs in serve mode (`context.mode === 'serve'`). Default: `false`. esbuild adjusts mappings to account for the banner automatically.
+- `sourcemap`: Emit an inline source map (data URI appended as `//# sourceMappingURL=...`). Accepts `boolean | 'onServer'`. When set to `'onServer'`, the source map is emitted only while kamado runs in serve mode (`context.mode === 'serve'`). Default: `'onServer'`. esbuild adjusts mappings to account for the banner automatically.
 
 ## License
 

--- a/packages/@kamado-io/script-compiler/src/script-compiler.spec.ts
+++ b/packages/@kamado-io/script-compiler/src/script-compiler.spec.ts
@@ -67,9 +67,14 @@ async function compile(
 const SOURCE_MAP_RE = /\/\/#\s*sourceMappingURL=data:application\/json;base64,/;
 
 describe('createScriptCompiler / sourcemap', () => {
-	test('omits source map by default', async () => {
+	test("defaults to 'onServer': omits source map in build mode", async () => {
 		const out = await compile('build', {});
 		expect(out).not.toMatch(SOURCE_MAP_RE);
+	});
+
+	test("defaults to 'onServer': emits source map in serve mode", async () => {
+		const out = await compile('serve', {});
+		expect(out).toMatch(SOURCE_MAP_RE);
 	});
 
 	test('emits inline source map when sourcemap is true', async () => {

--- a/packages/@kamado-io/script-compiler/src/script-compiler.spec.ts
+++ b/packages/@kamado-io/script-compiler/src/script-compiler.spec.ts
@@ -60,7 +60,7 @@ async function compile(
 	};
 	const entry = createScriptCompiler<MetaData>()(options);
 	const fn = await entry.compiler(makeContext(mode));
-	const out = await fn(file, () => '', undefined, false);
+	const out = await fn(file, () => Promise.resolve(''), undefined, false);
 	return typeof out === 'string' ? out : new TextDecoder().decode(out);
 }
 

--- a/packages/@kamado-io/script-compiler/src/script-compiler.spec.ts
+++ b/packages/@kamado-io/script-compiler/src/script-compiler.spec.ts
@@ -1,0 +1,94 @@
+import type { Context } from 'kamado/config';
+import type { CompilableFile, MetaData } from 'kamado/files';
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import { createScriptCompiler } from './script-compiler.js';
+
+let workDir: string;
+
+beforeEach(async () => {
+	workDir = await fs.mkdtemp(path.join(os.tmpdir(), 'script-compiler-spec-'));
+});
+
+afterEach(async () => {
+	await fs.rm(workDir, { recursive: true, force: true });
+});
+
+/**
+ *
+ * @param mode
+ */
+function makeContext(mode: 'serve' | 'build'): Context<MetaData> {
+	return {
+		mode,
+		pkg: { name: 'test', version: '1.0.0' },
+		dir: { root: workDir, input: workDir, output: workDir },
+		devServer: { port: 3000, host: 'localhost', open: false, transforms: [] },
+		compilers: () => [],
+	} as Context<MetaData>;
+}
+
+/**
+ *
+ * @param mode
+ * @param options
+ * @param source
+ */
+async function compile(
+	mode: 'serve' | 'build',
+	options: Parameters<ReturnType<typeof createScriptCompiler<MetaData>>>[0],
+	source = 'export const answer = 42;\n',
+) {
+	const inputPath = path.join(workDir, 'entry.ts');
+	await fs.writeFile(inputPath, source, 'utf8');
+	// outputPath is appended to os.tmpdir() inside the compiler; make it unique
+	// per call so parallel workers don't collide.
+	const uniqueOutput = path.join(path.basename(workDir), 'entry.js');
+	const file: CompilableFile = {
+		inputPath,
+		outputPath: uniqueOutput,
+		fileSlug: 'entry',
+		filePathStem: path.join(workDir, 'entry'),
+		url: '/entry.js',
+		extension: '.ts',
+		date: new Date(),
+	};
+	const entry = createScriptCompiler<MetaData>()(options);
+	const fn = await entry.compiler(makeContext(mode));
+	const out = await fn(file, () => '', undefined, false);
+	return typeof out === 'string' ? out : new TextDecoder().decode(out);
+}
+
+const SOURCE_MAP_RE = /\/\/#\s*sourceMappingURL=data:application\/json;base64,/;
+
+describe('createScriptCompiler / sourcemap', () => {
+	test('omits source map by default', async () => {
+		const out = await compile('build', {});
+		expect(out).not.toMatch(SOURCE_MAP_RE);
+	});
+
+	test('emits inline source map when sourcemap is true', async () => {
+		const out = await compile('build', { sourcemap: true });
+		expect(out).toMatch(SOURCE_MAP_RE);
+	});
+
+	test('omits source map when sourcemap is false', async () => {
+		const out = await compile('build', { sourcemap: false });
+		expect(out).not.toMatch(SOURCE_MAP_RE);
+	});
+
+	test("emits source map when sourcemap is 'onServer' and mode is serve", async () => {
+		const out = await compile('serve', { sourcemap: 'onServer' });
+		expect(out).toMatch(SOURCE_MAP_RE);
+	});
+
+	test("omits source map when sourcemap is 'onServer' and mode is build", async () => {
+		const out = await compile('build', { sourcemap: 'onServer' });
+		expect(out).not.toMatch(SOURCE_MAP_RE);
+	});
+});

--- a/packages/@kamado-io/script-compiler/src/script-compiler.ts
+++ b/packages/@kamado-io/script-compiler/src/script-compiler.ts
@@ -26,6 +26,11 @@ export interface ScriptCompilerOptions {
 	 * Can specify CreateBanner function or string
 	 */
 	readonly banner?: CreateBanner | string;
+	/**
+	 * Emit an inline source map (data URI appended as `//# sourceMappingURL=...`).
+	 * Default: false.
+	 */
+	readonly sourcemap?: boolean;
 }
 
 /**
@@ -70,6 +75,7 @@ export function createScriptCompiler<M extends MetaData>() {
 					outfile: tmpFilePath,
 					minify: options?.minifier,
 					charset: 'utf8',
+					sourcemap: options?.sourcemap ? 'inline' : false,
 					banner: {
 						js: banner,
 					},

--- a/packages/@kamado-io/script-compiler/src/script-compiler.ts
+++ b/packages/@kamado-io/script-compiler/src/script-compiler.ts
@@ -28,9 +28,13 @@ export interface ScriptCompilerOptions {
 	readonly banner?: CreateBanner | string;
 	/**
 	 * Emit an inline source map (data URI appended as `//# sourceMappingURL=...`).
+	 *
+	 * - `true` / `false`: always emit / never emit.
+	 * - `'onServer'`: emit only when kamado runs in serve mode (`context.mode === 'serve'`).
+	 *
 	 * Default: false.
 	 */
-	readonly sourcemap?: boolean;
+	readonly sourcemap?: boolean | 'onServer';
 }
 
 /**
@@ -53,7 +57,7 @@ export function createScriptCompiler<M extends MetaData>() {
 	return createCustomCompiler<ScriptCompilerOptions, M>(() => ({
 		defaultFiles: '**/*.{js,ts,jsx,tsx,mjs,cjs}',
 		defaultOutputExtension: '.js',
-		compile: (options) => async () => {
+		compile: (options) => async (context) => {
 			/**
 			 * When loading kamado.config.ts via getConfig(cosmiconfig),
 			 * if that kamado.config.ts invokes this compiler,
@@ -61,6 +65,11 @@ export function createScriptCompiler<M extends MetaData>() {
 			 * using a static import for esbuild will cause a special runtime error.
 			 */
 			const esbuild = await import('esbuild');
+
+			const enableSourcemap =
+				options?.sourcemap === 'onServer'
+					? context.mode === 'serve'
+					: !!options?.sourcemap;
 
 			return async (file) => {
 				const banner =
@@ -75,7 +84,7 @@ export function createScriptCompiler<M extends MetaData>() {
 					outfile: tmpFilePath,
 					minify: options?.minifier,
 					charset: 'utf8',
-					sourcemap: options?.sourcemap ? 'inline' : false,
+					sourcemap: enableSourcemap ? 'inline' : false,
 					banner: {
 						js: banner,
 					},

--- a/packages/@kamado-io/script-compiler/src/script-compiler.ts
+++ b/packages/@kamado-io/script-compiler/src/script-compiler.ts
@@ -66,6 +66,8 @@ export function createScriptCompiler<M extends MetaData>() {
 			 */
 			const esbuild = await import('esbuild');
 
+			// `context.mode` is fixed for the lifetime of a command, so evaluate
+			// the sourcemap flag once here rather than per-file.
 			const enableSourcemap =
 				options?.sourcemap === 'onServer'
 					? context.mode === 'serve'

--- a/packages/@kamado-io/script-compiler/src/script-compiler.ts
+++ b/packages/@kamado-io/script-compiler/src/script-compiler.ts
@@ -32,7 +32,7 @@ export interface ScriptCompilerOptions {
 	 * - `true` / `false`: always emit / never emit.
 	 * - `'onServer'`: emit only when kamado runs in serve mode (`context.mode === 'serve'`).
 	 *
-	 * Default: false.
+	 * Default: `'onServer'`.
 	 */
 	readonly sourcemap?: boolean | 'onServer';
 }
@@ -68,10 +68,9 @@ export function createScriptCompiler<M extends MetaData>() {
 
 			// `context.mode` is fixed for the lifetime of a command, so evaluate
 			// the sourcemap flag once here rather than per-file.
+			const sourcemapOption = options?.sourcemap ?? 'onServer';
 			const enableSourcemap =
-				options?.sourcemap === 'onServer'
-					? context.mode === 'serve'
-					: !!options?.sourcemap;
+				sourcemapOption === 'onServer' ? context.mode === 'serve' : sourcemapOption;
 
 			return async (file) => {
 				const banner =

--- a/packages/@kamado-io/style-compiler/README.md
+++ b/packages/@kamado-io/style-compiler/README.md
@@ -33,7 +33,7 @@ export default defineConfig({
 - `outputExtension` (optional): Output file extension (default: `'.css'`)
 - `alias`: Map of path aliases (key is alias name, value is actual path)
 - `banner`: Banner configuration (can specify CreateBanner function or string)
-- `sourcemap`: Emit an inline source map (`/*# sourceMappingURL=data:... */` appended to the output). Accepts `boolean | 'onServer'`. When set to `'onServer'`, the source map is emitted only while kamado runs in serve mode (`context.mode === 'serve'`). Default: `false`. When enabled, the banner is fed through PostCSS as a `/*!` important comment so cssnano preserves it and the source map line offsets stay correct.
+- `sourcemap`: Emit an inline source map (`/*# sourceMappingURL=data:... */` appended to the output). Accepts `boolean | 'onServer'`. When set to `'onServer'`, the source map is emitted only while kamado runs in serve mode (`context.mode === 'serve'`). Default: `'onServer'`. When enabled, the banner is fed through PostCSS as a `/*!` important comment so cssnano preserves it and the source map line offsets stay correct.
 
 ## License
 

--- a/packages/@kamado-io/style-compiler/README.md
+++ b/packages/@kamado-io/style-compiler/README.md
@@ -33,6 +33,7 @@ export default defineConfig({
 - `outputExtension` (optional): Output file extension (default: `'.css'`)
 - `alias`: Map of path aliases (key is alias name, value is actual path)
 - `banner`: Banner configuration (can specify CreateBanner function or string)
+- `sourcemap`: Emit an inline source map (`/*# sourceMappingURL=data:... */` appended to the output). Default: `false`. When enabled, the banner is fed through PostCSS as a `/*!` important comment so cssnano preserves it and the source map line offsets stay correct.
 
 ## License
 

--- a/packages/@kamado-io/style-compiler/README.md
+++ b/packages/@kamado-io/style-compiler/README.md
@@ -33,7 +33,7 @@ export default defineConfig({
 - `outputExtension` (optional): Output file extension (default: `'.css'`)
 - `alias`: Map of path aliases (key is alias name, value is actual path)
 - `banner`: Banner configuration (can specify CreateBanner function or string)
-- `sourcemap`: Emit an inline source map (`/*# sourceMappingURL=data:... */` appended to the output). Default: `false`. When enabled, the banner is fed through PostCSS as a `/*!` important comment so cssnano preserves it and the source map line offsets stay correct.
+- `sourcemap`: Emit an inline source map (`/*# sourceMappingURL=data:... */` appended to the output). Accepts `boolean | 'onServer'`. When set to `'onServer'`, the source map is emitted only while kamado runs in serve mode (`context.mode === 'serve'`). Default: `false`. When enabled, the banner is fed through PostCSS as a `/*!` important comment so cssnano preserves it and the source map line offsets stay correct.
 
 ## License
 

--- a/packages/@kamado-io/style-compiler/src/style-compiler.spec.ts
+++ b/packages/@kamado-io/style-compiler/src/style-compiler.spec.ts
@@ -84,9 +84,14 @@ async function compile(
 }
 
 describe('createStyleCompiler / sourcemap', () => {
-	test('omits source map by default', async () => {
+	test("defaults to 'onServer': omits source map in build mode", async () => {
 		const out = await compile('build', {});
 		expect(out).not.toMatch(SOURCE_MAP_RE);
+	});
+
+	test("defaults to 'onServer': emits source map in serve mode", async () => {
+		const out = await compile('serve', {});
+		expect(out).toMatch(SOURCE_MAP_RE);
 	});
 
 	test('emits inline source map when sourcemap is true', async () => {

--- a/packages/@kamado-io/style-compiler/src/style-compiler.spec.ts
+++ b/packages/@kamado-io/style-compiler/src/style-compiler.spec.ts
@@ -1,0 +1,136 @@
+import type { Context } from 'kamado/config';
+import type * as KamadoFiles from 'kamado/files';
+import type { CompilableFile, FileContent, MetaData } from 'kamado/files';
+
+import { describe, expect, test, vi } from 'vitest';
+
+import { createStyleCompiler } from './style-compiler.js';
+
+const mockFileContents = new Map<string, FileContent>();
+
+vi.mock('kamado/files', async (importOriginal) => {
+	const original = await importOriginal<typeof KamadoFiles>();
+	return {
+		...original,
+		getContentFromFile: vi.fn((file: CompilableFile) => {
+			const content = mockFileContents.get(file.inputPath);
+			if (!content) {
+				throw new Error(`ENOENT: no such file or directory, open '${file.inputPath}'`);
+			}
+			return Promise.resolve(content);
+		}),
+	};
+});
+
+/**
+ *
+ * @param inputPath
+ * @param css
+ */
+function setMockFile(inputPath: string, css: string) {
+	mockFileContents.set(inputPath, { content: css, raw: css });
+}
+
+/**
+ *
+ * @param mode
+ */
+function makeContext(mode: 'serve' | 'build'): Context<MetaData> {
+	return {
+		mode,
+		pkg: { name: 'test', version: '1.0.0' },
+		dir: { root: '/test', input: '/test/src', output: '/test/dist' },
+		devServer: { port: 3000, host: 'localhost', open: false, transforms: [] },
+		compilers: () => [],
+	} as Context<MetaData>;
+}
+
+/**
+ *
+ * @param inputPath
+ */
+function makeFile(inputPath = '/test/src/style.css'): CompilableFile {
+	return {
+		inputPath,
+		outputPath: '/test/dist/style.css',
+		fileSlug: 'style',
+		filePathStem: '/test/src/style',
+		url: '/style.css',
+		extension: '.css',
+		date: new Date(),
+	};
+}
+
+const SOURCE_MAP_RE = /\/\*#\s*sourceMappingURL=data:application\/json;base64,/;
+
+/**
+ *
+ * @param mode
+ * @param options
+ * @param css
+ */
+async function compile(
+	mode: 'serve' | 'build',
+	options: Parameters<ReturnType<typeof createStyleCompiler<MetaData>>>[0],
+	css = '.a{color:red}',
+) {
+	mockFileContents.clear();
+	const file = makeFile();
+	setMockFile(file.inputPath, css);
+	const entry = createStyleCompiler<MetaData>()(options);
+	const fn = await entry.compiler(makeContext(mode));
+	const out = await fn(file, () => '', undefined, false);
+	return typeof out === 'string' ? out : new TextDecoder().decode(out);
+}
+
+describe('createStyleCompiler / sourcemap', () => {
+	test('omits source map by default', async () => {
+		const out = await compile('build', {});
+		expect(out).not.toMatch(SOURCE_MAP_RE);
+	});
+
+	test('emits inline source map when sourcemap is true', async () => {
+		const out = await compile('build', { sourcemap: true });
+		expect(out).toMatch(SOURCE_MAP_RE);
+	});
+
+	test('omits source map when sourcemap is false', async () => {
+		const out = await compile('build', { sourcemap: false });
+		expect(out).not.toMatch(SOURCE_MAP_RE);
+	});
+
+	test("emits source map when sourcemap is 'onServer' and mode is serve", async () => {
+		const out = await compile('serve', { sourcemap: 'onServer' });
+		expect(out).toMatch(SOURCE_MAP_RE);
+	});
+
+	test("omits source map when sourcemap is 'onServer' and mode is build", async () => {
+		const out = await compile('build', { sourcemap: 'onServer' });
+		expect(out).not.toMatch(SOURCE_MAP_RE);
+	});
+});
+
+describe('createStyleCompiler / banner parity', () => {
+	test('banner text is preserved through cssnano regardless of sourcemap flag', async () => {
+		const banner = 'rev. 2026-05-15\ncopyright marker';
+		const off = await compile('build', { banner });
+		const on = await compile('serve', { sourcemap: 'onServer', banner });
+		expect(off).toContain('rev. 2026-05-15');
+		expect(off).toContain('copyright marker');
+		expect(on).toContain('rev. 2026-05-15');
+		expect(on).toContain('copyright marker');
+	});
+
+	test('banner survives minification (preserved as /*! comment)', async () => {
+		const banner = '/*\nkeep me\n*/';
+		const out = await compile('build', { banner });
+		expect(out).toContain('keep me');
+		expect(out).toContain('/*!');
+	});
+
+	test('plain string banner is wrapped in a /*! comment safely', async () => {
+		const out = await compile('build', { banner: 'plain text marker' });
+		expect(out).toContain('plain text marker');
+		expect(out).toContain('/*!');
+	});
+});

--- a/packages/@kamado-io/style-compiler/src/style-compiler.spec.ts
+++ b/packages/@kamado-io/style-compiler/src/style-compiler.spec.ts
@@ -79,7 +79,7 @@ async function compile(
 	setMockFile(file.inputPath, css);
 	const entry = createStyleCompiler<MetaData>()(options);
 	const fn = await entry.compiler(makeContext(mode));
-	const out = await fn(file, () => '', undefined, false);
+	const out = await fn(file, () => Promise.resolve(''), undefined, false);
 	return typeof out === 'string' ? out : new TextDecoder().decode(out);
 }
 

--- a/packages/@kamado-io/style-compiler/src/style-compiler.ts
+++ b/packages/@kamado-io/style-compiler/src/style-compiler.ts
@@ -31,7 +31,7 @@ export interface StyleCompilerOptions {
 	 * - `true` / `false`: always emit / never emit.
 	 * - `'onServer'`: emit only when kamado runs in serve mode (`context.mode === 'serve'`).
 	 *
-	 * Default: false.
+	 * Default: `'onServer'`.
 	 */
 	readonly sourcemap?: boolean | 'onServer';
 }
@@ -84,10 +84,9 @@ export function createStyleCompiler<M extends MetaData>() {
 		compile: (options) => (context) => {
 			// `context.mode` is fixed for the lifetime of a command, so evaluate
 			// the sourcemap flag once here rather than per-file.
+			const sourcemapOption = options?.sourcemap ?? 'onServer';
 			const enableSourcemap =
-				options?.sourcemap === 'onServer'
-					? context.mode === 'serve'
-					: !!options?.sourcemap;
+				sourcemapOption === 'onServer' ? context.mode === 'serve' : sourcemapOption;
 
 			return async (file, _, __, cache) => {
 				// Configure plugins with alias resolver for postcss-import

--- a/packages/@kamado-io/style-compiler/src/style-compiler.ts
+++ b/packages/@kamado-io/style-compiler/src/style-compiler.ts
@@ -32,12 +32,34 @@ export interface StyleCompilerOptions {
 	 * - `'onServer'`: emit only when kamado runs in serve mode (`context.mode === 'serve'`).
 	 *
 	 * Default: false.
-	 *
-	 * When enabled, the banner is prepended *before* PostCSS processing so that
-	 * the resulting source map line offsets stay correct. The banner is rewritten
-	 * to a `/*!` important comment so cssnano preserves it through minification.
 	 */
 	readonly sourcemap?: boolean | 'onServer';
+}
+
+/**
+ * Coerces a banner string into a `/*! ... *\/` important comment so it can be
+ * safely prepended to PostCSS input and survive cssnano minification.
+ *
+ * - `/*! ... *\/` → returned as-is.
+ * - `/* ... *\/` → leading `/*` rewritten to `/*!`.
+ * - anything else (including plain strings without comment markers) → wrapped
+ *   in `/*! ... *\/`. Any embedded `*\/` is split with a space so it cannot
+ *   prematurely close the surrounding comment.
+ * @param raw
+ */
+function normalizeBanner(raw: string): string {
+	const trimmed = raw.trim();
+	if (!trimmed) {
+		return '';
+	}
+	if (trimmed.startsWith('/*!')) {
+		return trimmed;
+	}
+	if (trimmed.startsWith('/*') && trimmed.endsWith('*/')) {
+		return '/*!' + trimmed.slice(2);
+	}
+	const safe = trimmed.replaceAll('*/', '* /');
+	return `/*!\n${safe}\n*/`;
 }
 
 /**
@@ -60,6 +82,8 @@ export function createStyleCompiler<M extends MetaData>() {
 		defaultFiles: '**/*.css',
 		defaultOutputExtension: '.css',
 		compile: (options) => (context) => {
+			// `context.mode` is fixed for the lifetime of a command, so evaluate
+			// the sourcemap flag once here rather than per-file.
 			const enableSourcemap =
 				options?.sourcemap === 'onServer'
 					? context.mode === 'serve'
@@ -128,32 +152,23 @@ export function createStyleCompiler<M extends MetaData>() {
 
 				const css = await getContentFromFile(file, cache);
 
-				const banner =
+				const rawBanner =
 					typeof options?.banner === 'string'
 						? options.banner
 						: createBanner(options?.banner?.());
+				// Normalize to a `/*! ... */` important comment so that:
+				// 1) cssnano preserves it through minification (the `!` flag),
+				// 2) it can be safely prepended to the PostCSS input — which
+				//    keeps inline source map line offsets correct and ensures
+				//    the output is identical regardless of the sourcemap flag.
+				const banner = normalizeBanner(rawBanner);
 
-				if (enableSourcemap) {
-					// Rewrite leading `/*` → `/*!` so cssnano preserves the banner;
-					// including it in the PostCSS input keeps the inline source map
-					// line offsets correct.
-					const inputBanner = banner.replace(/^\/\*(?!!)/, '/*!');
-					const result = await postcss(plugins).process(
-						inputBanner + '\n' + css.content,
-						{
-							from: file.inputPath,
-							to: undefined,
-							map: { inline: true },
-						},
-					);
-					return result.css;
-				}
-
-				const result = await postcss(plugins).process(css.content, {
+				const result = await postcss(plugins).process(banner + '\n' + css.content, {
 					from: file.inputPath,
 					to: undefined,
+					...(enableSourcemap ? { map: { inline: true } } : {}),
 				});
-				return banner + '\n' + result.css;
+				return result.css;
 			};
 		},
 	}));

--- a/packages/@kamado-io/style-compiler/src/style-compiler.ts
+++ b/packages/@kamado-io/style-compiler/src/style-compiler.ts
@@ -27,13 +27,17 @@ export interface StyleCompilerOptions {
 	readonly banner?: CreateBanner | string;
 	/**
 	 * Emit an inline source map (`/*# sourceMappingURL=data:... *\/` appended to the output).
+	 *
+	 * - `true` / `false`: always emit / never emit.
+	 * - `'onServer'`: emit only when kamado runs in serve mode (`context.mode === 'serve'`).
+	 *
 	 * Default: false.
 	 *
 	 * When enabled, the banner is prepended *before* PostCSS processing so that
 	 * the resulting source map line offsets stay correct. The banner is rewritten
 	 * to a `/*!` important comment so cssnano preserves it through minification.
 	 */
-	readonly sourcemap?: boolean;
+	readonly sourcemap?: boolean | 'onServer';
 }
 
 /**
@@ -55,7 +59,12 @@ export function createStyleCompiler<M extends MetaData>() {
 	return createCustomCompiler<StyleCompilerOptions, M>(() => ({
 		defaultFiles: '**/*.css',
 		defaultOutputExtension: '.css',
-		compile: (options) => () => {
+		compile: (options) => (context) => {
+			const enableSourcemap =
+				options?.sourcemap === 'onServer'
+					? context.mode === 'serve'
+					: !!options?.sourcemap;
+
 			return async (file, _, __, cache) => {
 				// Configure plugins with alias resolver for postcss-import
 				const plugins: postcss.AcceptedPlugin[] = [
@@ -124,7 +133,7 @@ export function createStyleCompiler<M extends MetaData>() {
 						? options.banner
 						: createBanner(options?.banner?.());
 
-				if (options?.sourcemap) {
+				if (enableSourcemap) {
 					// Rewrite leading `/*` → `/*!` so cssnano preserves the banner;
 					// including it in the PostCSS input keeps the inline source map
 					// line offsets correct.

--- a/packages/@kamado-io/style-compiler/src/style-compiler.ts
+++ b/packages/@kamado-io/style-compiler/src/style-compiler.ts
@@ -25,6 +25,15 @@ export interface StyleCompilerOptions {
 	 * Can specify CreateBanner function or string
 	 */
 	readonly banner?: CreateBanner | string;
+	/**
+	 * Emit an inline source map (`/*# sourceMappingURL=data:... *\/` appended to the output).
+	 * Default: false.
+	 *
+	 * When enabled, the banner is prepended *before* PostCSS processing so that
+	 * the resulting source map line offsets stay correct. The banner is rewritten
+	 * to a `/*!` important comment so cssnano preserves it through minification.
+	 */
+	readonly sourcemap?: boolean;
 }
 
 /**
@@ -110,17 +119,31 @@ export function createStyleCompiler<M extends MetaData>() {
 
 				const css = await getContentFromFile(file, cache);
 
-				// Process CSS with PostCSS
-				const result = await postcss(plugins).process(css.content, {
-					from: file.inputPath,
-					to: undefined,
-				});
-
 				const banner =
 					typeof options?.banner === 'string'
 						? options.banner
 						: createBanner(options?.banner?.());
 
+				if (options?.sourcemap) {
+					// Rewrite leading `/*` → `/*!` so cssnano preserves the banner;
+					// including it in the PostCSS input keeps the inline source map
+					// line offsets correct.
+					const inputBanner = banner.replace(/^\/\*(?!!)/, '/*!');
+					const result = await postcss(plugins).process(
+						inputBanner + '\n' + css.content,
+						{
+							from: file.inputPath,
+							to: undefined,
+							map: { inline: true },
+						},
+					);
+					return result.css;
+				}
+
+				const result = await postcss(plugins).process(css.content, {
+					from: file.inputPath,
+					to: undefined,
+				});
 				return banner + '\n' + result.css;
 			};
 		},

--- a/packages/kamado/README.ja.md
+++ b/packages/kamado/README.ja.md
@@ -191,6 +191,7 @@ def(createPageCompiler(), {
 - `outputExtension`（オプション）: 出力ファイルの拡張子（デフォルト: `'.css'`）
 - `alias`: パスエイリアスのマップ（PostCSSの`@import`で使用）
 - `banner`: バナー設定（CreateBanner関数または文字列を指定可能）
+- `sourcemap`: 出力末尾にインラインソースマップを付与する。デフォルト: `false`
 
 **例**: `.scss`ファイルを`.css`にコンパイルし、ソースファイルを無視する場合：
 
@@ -213,6 +214,7 @@ def(createStyleCompiler(), {
 - `alias`: パスエイリアスのマップ（esbuildのエイリアス）
 - `minifier`: ミニファイを有効にするか
 - `banner`: バナー設定（CreateBanner関数または文字列を指定可能）
+- `sourcemap`: 出力末尾にインラインソースマップを付与する。デフォルト: `false`
 
 **例**: TypeScriptファイルをJavaScriptにコンパイルする場合：
 
@@ -224,6 +226,26 @@ def(createScriptCompiler(), {
 	alias: {
 		'@': path.resolve(import.meta.dirname, '__assets', '_libs'),
 	},
+});
+```
+
+##### コマンドごとにオプションを切り替える
+
+コンパイラーのオプションは`kamado.config.ts`の読み込み時に評価されるため、`kamado server`と`kamado build`で値を変えたい場合（例: ソースマップを開発サーバー時だけ出力する）は、設定ファイル内でCLIコマンドを判定して分岐します：
+
+```ts
+const isServe = process.argv.includes('server');
+
+export default defineConfig({
+	compilers: (def) => [
+		def(createScriptCompiler(), {
+			minifier: !isServe,
+			sourcemap: isServe,
+		}),
+		def(createStyleCompiler(), {
+			sourcemap: isServe,
+		}),
+	],
 });
 ```
 

--- a/packages/kamado/README.ja.md
+++ b/packages/kamado/README.ja.md
@@ -191,7 +191,7 @@ def(createPageCompiler(), {
 - `outputExtension`（オプション）: 出力ファイルの拡張子（デフォルト: `'.css'`）
 - `alias`: パスエイリアスのマップ（PostCSSの`@import`で使用）
 - `banner`: バナー設定（CreateBanner関数または文字列を指定可能）
-- `sourcemap`: 出力末尾にインラインソースマップを付与する。`boolean | 'onServer'`を受け付ける。`'onServer'`を指定すると、kamadoがserveモードで動作している間のみソースマップを出力する。デフォルト: `false`
+- `sourcemap`: 出力末尾にインラインソースマップを付与する。`boolean | 'onServer'`を受け付ける。`'onServer'`を指定すると、kamadoがserveモードで動作している間のみソースマップを出力する。デフォルト: `'onServer'`
 
 **例**: `.scss`ファイルを`.css`にコンパイルし、ソースファイルを無視する場合：
 
@@ -214,7 +214,7 @@ def(createStyleCompiler(), {
 - `alias`: パスエイリアスのマップ（esbuildのエイリアス）
 - `minifier`: ミニファイを有効にするか
 - `banner`: バナー設定（CreateBanner関数または文字列を指定可能）
-- `sourcemap`: 出力末尾にインラインソースマップを付与する。`boolean | 'onServer'`を受け付ける。`'onServer'`を指定すると、kamadoがserveモードで動作している間のみソースマップを出力する。デフォルト: `false`
+- `sourcemap`: 出力末尾にインラインソースマップを付与する。`boolean | 'onServer'`を受け付ける。`'onServer'`を指定すると、kamadoがserveモードで動作している間のみソースマップを出力する。デフォルト: `'onServer'`
 
 **例**: TypeScriptファイルをJavaScriptにコンパイルする場合：
 
@@ -231,16 +231,16 @@ def(createScriptCompiler(), {
 
 ##### コマンドごとにソースマップを切り替える
 
-`sourcemap: 'onServer'`を指定すると、`kamado server`の間のみインラインソースマップを出力します：
+デフォルトは`'onServer'`で、`kamado server`の間のみインラインソースマップを出力し、`kamado build`では出力されません。常に出力したい場合は`true`、常に出力したくない場合は`false`を指定します：
 
 ```ts
 export default defineConfig({
 	compilers: (def) => [
 		def(createScriptCompiler(), {
-			sourcemap: 'onServer',
+			sourcemap: true, // 常に出力（build + serve）
 		}),
 		def(createStyleCompiler(), {
-			sourcemap: 'onServer',
+			sourcemap: false, // 出力しない
 		}),
 	],
 });

--- a/packages/kamado/README.ja.md
+++ b/packages/kamado/README.ja.md
@@ -191,7 +191,7 @@ def(createPageCompiler(), {
 - `outputExtension`（オプション）: 出力ファイルの拡張子（デフォルト: `'.css'`）
 - `alias`: パスエイリアスのマップ（PostCSSの`@import`で使用）
 - `banner`: バナー設定（CreateBanner関数または文字列を指定可能）
-- `sourcemap`: 出力末尾にインラインソースマップを付与する。デフォルト: `false`
+- `sourcemap`: 出力末尾にインラインソースマップを付与する。`boolean | 'onServer'`を受け付ける。`'onServer'`を指定すると、kamadoがserveモードで動作している間のみソースマップを出力する。デフォルト: `false`
 
 **例**: `.scss`ファイルを`.css`にコンパイルし、ソースファイルを無視する場合：
 
@@ -214,7 +214,7 @@ def(createStyleCompiler(), {
 - `alias`: パスエイリアスのマップ（esbuildのエイリアス）
 - `minifier`: ミニファイを有効にするか
 - `banner`: バナー設定（CreateBanner関数または文字列を指定可能）
-- `sourcemap`: 出力末尾にインラインソースマップを付与する。デフォルト: `false`
+- `sourcemap`: 出力末尾にインラインソースマップを付与する。`boolean | 'onServer'`を受け付ける。`'onServer'`を指定すると、kamadoがserveモードで動作している間のみソースマップを出力する。デフォルト: `false`
 
 **例**: TypeScriptファイルをJavaScriptにコンパイルする場合：
 
@@ -229,21 +229,18 @@ def(createScriptCompiler(), {
 });
 ```
 
-##### コマンドごとにオプションを切り替える
+##### コマンドごとにソースマップを切り替える
 
-コンパイラーのオプションは`kamado.config.ts`の読み込み時に評価されるため、`kamado server`と`kamado build`で値を変えたい場合（例: ソースマップを開発サーバー時だけ出力する）は、設定ファイル内でCLIコマンドを判定して分岐します：
+`sourcemap: 'onServer'`を指定すると、`kamado server`の間のみインラインソースマップを出力します：
 
 ```ts
-const isServe = process.argv.includes('server');
-
 export default defineConfig({
 	compilers: (def) => [
 		def(createScriptCompiler(), {
-			minifier: !isServe,
-			sourcemap: isServe,
+			sourcemap: 'onServer',
 		}),
 		def(createStyleCompiler(), {
-			sourcemap: isServe,
+			sourcemap: 'onServer',
 		}),
 	],
 });

--- a/packages/kamado/README.md
+++ b/packages/kamado/README.md
@@ -191,7 +191,7 @@ def(createPageCompiler(), {
 - `outputExtension` (optional): Output file extension (default: `'.css'`)
 - `alias`: Path alias map (used in PostCSS `@import`)
 - `banner`: Banner configuration (can specify CreateBanner function or string)
-- `sourcemap`: Emit an inline source map appended to the output. Default: `false`.
+- `sourcemap`: Emit an inline source map appended to the output. Accepts `boolean | 'onServer'`. When set to `'onServer'`, the source map is emitted only while kamado runs in serve mode. Default: `false`.
 
 **Example**: To compile `.scss` files to `.css` while ignoring source files:
 
@@ -214,7 +214,7 @@ def(createStyleCompiler(), {
 - `alias`: Path alias map (esbuild alias)
 - `minifier`: Whether to enable minification
 - `banner`: Banner configuration (can specify CreateBanner function or string)
-- `sourcemap`: Emit an inline source map appended to the output. Default: `false`.
+- `sourcemap`: Emit an inline source map appended to the output. Accepts `boolean | 'onServer'`. When set to `'onServer'`, the source map is emitted only while kamado runs in serve mode. Default: `false`.
 
 **Example**: To compile TypeScript files to JavaScript:
 
@@ -229,21 +229,18 @@ def(createScriptCompiler(), {
 });
 ```
 
-##### Switching options per command
+##### Switching the source map per command
 
-Compiler options are resolved when `kamado.config.ts` loads, so to vary them between `kamado server` and `kamado build` (e.g. to emit source maps only when running the dev server), branch on the CLI command in the config itself:
+Pass `sourcemap: 'onServer'` to emit the inline source map only during `kamado server`:
 
 ```ts
-const isServe = process.argv.includes('server');
-
 export default defineConfig({
 	compilers: (def) => [
 		def(createScriptCompiler(), {
-			minifier: !isServe,
-			sourcemap: isServe,
+			sourcemap: 'onServer',
 		}),
 		def(createStyleCompiler(), {
-			sourcemap: isServe,
+			sourcemap: 'onServer',
 		}),
 	],
 });

--- a/packages/kamado/README.md
+++ b/packages/kamado/README.md
@@ -191,6 +191,7 @@ def(createPageCompiler(), {
 - `outputExtension` (optional): Output file extension (default: `'.css'`)
 - `alias`: Path alias map (used in PostCSS `@import`)
 - `banner`: Banner configuration (can specify CreateBanner function or string)
+- `sourcemap`: Emit an inline source map appended to the output. Default: `false`.
 
 **Example**: To compile `.scss` files to `.css` while ignoring source files:
 
@@ -213,6 +214,7 @@ def(createStyleCompiler(), {
 - `alias`: Path alias map (esbuild alias)
 - `minifier`: Whether to enable minification
 - `banner`: Banner configuration (can specify CreateBanner function or string)
+- `sourcemap`: Emit an inline source map appended to the output. Default: `false`.
 
 **Example**: To compile TypeScript files to JavaScript:
 
@@ -224,6 +226,26 @@ def(createScriptCompiler(), {
 	alias: {
 		'@': path.resolve(import.meta.dirname, '__assets', '_libs'),
 	},
+});
+```
+
+##### Switching options per command
+
+Compiler options are resolved when `kamado.config.ts` loads, so to vary them between `kamado server` and `kamado build` (e.g. to emit source maps only when running the dev server), branch on the CLI command in the config itself:
+
+```ts
+const isServe = process.argv.includes('server');
+
+export default defineConfig({
+	compilers: (def) => [
+		def(createScriptCompiler(), {
+			minifier: !isServe,
+			sourcemap: isServe,
+		}),
+		def(createStyleCompiler(), {
+			sourcemap: isServe,
+		}),
+	],
 });
 ```
 

--- a/packages/kamado/README.md
+++ b/packages/kamado/README.md
@@ -191,7 +191,7 @@ def(createPageCompiler(), {
 - `outputExtension` (optional): Output file extension (default: `'.css'`)
 - `alias`: Path alias map (used in PostCSS `@import`)
 - `banner`: Banner configuration (can specify CreateBanner function or string)
-- `sourcemap`: Emit an inline source map appended to the output. Accepts `boolean | 'onServer'`. When set to `'onServer'`, the source map is emitted only while kamado runs in serve mode. Default: `false`.
+- `sourcemap`: Emit an inline source map appended to the output. Accepts `boolean | 'onServer'`. When set to `'onServer'`, the source map is emitted only while kamado runs in serve mode. Default: `'onServer'`.
 
 **Example**: To compile `.scss` files to `.css` while ignoring source files:
 
@@ -214,7 +214,7 @@ def(createStyleCompiler(), {
 - `alias`: Path alias map (esbuild alias)
 - `minifier`: Whether to enable minification
 - `banner`: Banner configuration (can specify CreateBanner function or string)
-- `sourcemap`: Emit an inline source map appended to the output. Accepts `boolean | 'onServer'`. When set to `'onServer'`, the source map is emitted only while kamado runs in serve mode. Default: `false`.
+- `sourcemap`: Emit an inline source map appended to the output. Accepts `boolean | 'onServer'`. When set to `'onServer'`, the source map is emitted only while kamado runs in serve mode. Default: `'onServer'`.
 
 **Example**: To compile TypeScript files to JavaScript:
 
@@ -231,16 +231,16 @@ def(createScriptCompiler(), {
 
 ##### Switching the source map per command
 
-Pass `sourcemap: 'onServer'` to emit the inline source map only during `kamado server`:
+The default is `'onServer'`, so the inline source map is emitted only during `kamado server` and omitted in `kamado build`. Pass `true` to always emit, or `false` to always omit:
 
 ```ts
 export default defineConfig({
 	compilers: (def) => [
 		def(createScriptCompiler(), {
-			sourcemap: 'onServer',
+			sourcemap: true, // always emit (build + serve)
 		}),
 		def(createStyleCompiler(), {
-			sourcemap: 'onServer',
+			sourcemap: false, // never emit
 		}),
 	],
 });


### PR DESCRIPTION
## Summary
- Add opt-in `sourcemap?: boolean` option to `@kamado-io/script-compiler` and `@kamado-io/style-compiler`. Default `false`; when `true`, emits an inline source map appended to the output.
- `script-compiler`: passes `sourcemap: 'inline'` to esbuild — banner offsets are handled automatically by esbuild.
- `style-compiler`: feeds the banner through PostCSS as a `/*!` important comment when sourcemap is enabled, so cssnano preserves it and the inline source map's line offsets stay correct.
- Document the new option in each package README and in the kamado README (en/ja), including a *Switching options per command* example using `process.argv.includes('server')` to vary options between `kamado server` and `kamado build`.

## Test plan
- [x] \`yarn lint\` — pass
- [x] \`yarn build\` — pass
- [x] \`yarn test\` — pass
- [ ] Manually verify inline source maps appear in dev server output for both JS and CSS, and that they are absent in \`yarn build\` output when \`sourcemap\` is left unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)