### PR TITLE
fix(github): automerge renovate vulnerability alert PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,7 +16,8 @@
 	"internalChecksFilter": "strict",
 	"osvVulnerabilityAlerts": true,
 	"vulnerabilityAlerts": {
-		"minimumReleaseAge": null
+		"minimumReleaseAge": null,
+		"automerge": true
 	},
 	"autoApprove": true,
 	"labels": ["Dependencies", "Renovate"],


### PR DESCRIPTION
## 概要

脆弱性修正PR（例: PR #191 の hono 4.12.32→4.12.34 [security]）が自動マージされていなかった問題を修正しました。

## 原因

`.github/renovate.json` の `vulnerabilityAlerts` ブロックには `minimumReleaseAge: null` のみが設定されており、`automerge: true` が明記されていませんでした。そのため、`packageRules` の条件（`matchUpdateTypes: ["minor","patch","pin","digest"]` かつ `matchCurrentVersion: "!/^0/"` の場合に `automerge: true`）を満たす通常のminor/patch更新は自動マージされる一方、脆弱性修正PRは同様の条件を満たしていても自動マージされていませんでした。

## 修正内容

`vulnerabilityAlerts` ブロックに `"automerge": true` を追加しました（既存の `minimumReleaseAge: null` は維持）。

```diff
 "vulnerabilityAlerts": {
-  "minimumReleaseAge": null
+  "minimumReleaseAge": null,
+  "automerge": true
 },
```