### PR TITLE
fix(github): force Renovate direct merge to preserve branch protection bypass

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"configMigration": true,
+	"platformAutomerge": false,
 	"extends": [
 		"config:recommended",
 		"docker:pinDigests",


### PR DESCRIPTION
## 概要

`allow_auto_merge` を `false` から `true` に変更したことで、Renovate の automerge 方式が「GitHub native auto-merge 予約」に切り替わってしまう退行が発生していました。

## 問題

- 本リポジトリの dev ブランチ保護には `required_approving_review_count: 1` が設定されていますが、`bypass_pull_request_allowances` に Renovate app が登録されているため、従来 Renovate は自身の REST/GraphQL directマージ API を使ってレビュー要件をバイパスし、正常に automerge できていました（実績: 過去多数の PR で `mergedBy: app/renovate`）。
- リポジトリ設定 `allow_auto_merge` を `true` に変更したところ、Renovate が directマージではなく GitHub native auto-merge 予約方式を使うようになりました。
- native auto-merge 予約はブランチ保護の `bypass_pull_request_allowances` を評価しないため、レビュー必須要件がそのまま適用されてしまいます。
- この結果、CI が完全に成功済みの PR（例: #177, #162）が auto-merge 予約されたまま `mergeStateStatus: BLOCKED`, `reviewDecision: REVIEW_REQUIRED` の状態で滞留し、いつまでもマージされない詰まりが発生していました。

## 対応

`.github/renovate.json` のトップレベルに `"platformAutomerge": false` を追加しました。

これにより `allow_auto_merge` の値に関わらず、Renovate は常に自前の directマージ API（bypass が効く方式）を使うようになり、従来通りの automerge 挙動に戻ります。

## 補足

既存の `packageRules` 内の automerge 設定（non-major updates の automerge、vulnerabilityAlerts の automerge 等）はそのまま維持しています。