### PR TITLE
chore(deps): update @d-zero/* dependencies

### DIFF
--- a/packages/@kamado-io/page-compiler/package.json
+++ b/packages/@kamado-io/page-compiler/package.json
@@ -77,7 +77,7 @@
 		"dist"
 	],
 	"dependencies": {
-		"@d-zero/shared": "0.22.3",
+		"@d-zero/shared": "0.22.5",
 		"ansi-colors": "4.1.3",
 		"character-entities": "2.0.2",
 		"fast-glob": "3.3.3",

--- a/packages/kamado/package.json
+++ b/packages/kamado/package.json
@@ -30,9 +30,9 @@
 		"dist"
 	],
 	"dependencies": {
-		"@d-zero/dealer": "1.10.2",
-		"@d-zero/roar": "2.1.3",
-		"@d-zero/shared": "0.22.3",
+		"@d-zero/dealer": "1.10.4",
+		"@d-zero/roar": "2.2.0",
+		"@d-zero/shared": "0.22.5",
 		"@hono/node-server": "2.1.0",
 		"ansi-colors": "4.1.3",
 		"character-entities": "2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -997,13 +997,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@d-zero/dealer@npm:1.10.2":
-  version: 1.10.2
-  resolution: "@d-zero/dealer@npm:1.10.2"
+"@d-zero/dealer@npm:1.10.4":
+  version: 1.10.4
+  resolution: "@d-zero/dealer@npm:1.10.4"
   dependencies:
-    "@d-zero/shared": "npm:0.22.3"
+    "@d-zero/shared": "npm:0.22.5"
     ansi-colors: "npm:4.1.3"
-  checksum: 10c0/12bee8088d31ccb123d294a81fcf4f451c71a347b29e2b1e5d9df527872e36ae94377bf537662088ce0a7a425df06184e54fe8d213841ccd5a7a1c4d49797c90
+  checksum: 10c0/6d85dc7b7f810c12be96ce2683c730cd7a41206991f7941afaf9c4d1b50911f676e58a57609759de447a173dc32c6ec58b4e20a471f77a1cb3ca469d3e8018c3
   languageName: node
   linkType: hard
 
@@ -1047,18 +1047,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@d-zero/roar@npm:2.1.3":
-  version: 2.1.3
-  resolution: "@d-zero/roar@npm:2.1.3"
+"@d-zero/roar@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@d-zero/roar@npm:2.2.0"
   dependencies:
     yargs-parser: "npm:22.0.0"
-  checksum: 10c0/992d6e010c0c74593c2a87d1c171db87e9c232beb367d44a9af61beca11df44f1982e257480de4ef0847be2bfb486d30f4f4bc06b24142d93c28a76a631c6ac6
+  checksum: 10c0/d2dbedaa8afb4c7c41beaea9750ed93200f1c4cd369ed13b21ffc3d6404b780f7bcfc2bf9b1b9a075d8d55919aa5e7ba07202f06e6c57a14b93828b8a02cd2be
   languageName: node
   linkType: hard
 
-"@d-zero/shared@npm:0.22.3":
-  version: 0.22.3
-  resolution: "@d-zero/shared@npm:0.22.3"
+"@d-zero/shared@npm:0.22.5":
+  version: 0.22.5
+  resolution: "@d-zero/shared@npm:0.22.5"
   dependencies:
     "@holiday-jp/holiday_jp": "npm:2.5.1"
     await-event-emitter: "npm:2.0.2"
@@ -1067,7 +1067,7 @@ __metadata:
     front-matter: "npm:4.0.2"
     micromatch: "npm:4.0.8"
     sanitize-filename: "npm:1.6.4"
-  checksum: 10c0/2458def65fafe5e0ae652132ef0cafc862974245779d88808ec1c35a5dba4ec2e5a82a32c6d631241612ded2daae5207602593161d68b521af824b0f7dd91aaa
+  checksum: 10c0/c0f0fff768db6a03ac5255383bdd4efeea00d2c18c663fbb6203a6db119d48e072be002d72b8be1f294e6ce847b5d2485a4e79e499c0e0673e5bcd259e064a4e
   languageName: node
   linkType: hard
 
@@ -2111,7 +2111,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@kamado-io/page-compiler@workspace:packages/@kamado-io/page-compiler"
   dependencies:
-    "@d-zero/shared": "npm:0.22.3"
+    "@d-zero/shared": "npm:0.22.5"
     "@types/html-minifier-terser": "npm:7.0.2"
     ansi-colors: "npm:4.1.3"
     character-entities: "npm:2.0.2"
@@ -8553,9 +8553,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "kamado@workspace:packages/kamado"
   dependencies:
-    "@d-zero/dealer": "npm:1.10.2"
-    "@d-zero/roar": "npm:2.1.3"
-    "@d-zero/shared": "npm:0.22.3"
+    "@d-zero/dealer": "npm:1.10.4"
+    "@d-zero/roar": "npm:2.2.0"
+    "@d-zero/shared": "npm:0.22.5"
     "@hono/node-server": "npm:2.1.0"
     "@types/node": "npm:24.13.3"
     "@types/picomatch": "npm:4.0.3"


### PR DESCRIPTION
## 概要

`@d-zero/*` 系依存パッケージを最新版に更新する。

## 変更内容

- `@d-zero/dealer`: 1.10.2 → 1.10.4（`packages/kamado`）
- `@d-zero/roar`: 2.1.3 → 2.2.0（`packages/kamado`）
- `@d-zero/shared`: 0.22.3 → 0.22.5（`packages/kamado`, `packages/@kamado-io/page-compiler`）

ルート `package.json` の `@d-zero/*` 系 devDependencies（`commitlint-config` 等）は既に最新版のため変更なし。

`kamado` 本体・`@kamado-io/*` 系はworkspace内部パッケージ（lerna fixedバージョニング管理）のため今回の更新対象外。

## 動作確認

- `yarn build`: 成功
- `yarn test`: 513件成功
- `yarn lint`: 成功（既存の warning のみ、本変更と無関係）
