### PR TITLE
chore: lay groundwork for Explicit Resource Management

### DIFF
--- a/packages/@kamado-io/page-compiler/package.json
+++ b/packages/@kamado-io/page-compiler/package.json
@@ -69,6 +69,9 @@
 			"default": "./dist/features/title-utils.js"
 		}
 	},
+	"engines": {
+		"node": ">=24.11.0"
+	},
 	"scripts": {
 		"build": "tsc --project tsconfig.build.json",
 		"dev": "tsc --watch --project tsconfig.build.json"
@@ -77,7 +80,7 @@
 		"dist"
 	],
 	"dependencies": {
-		"@d-zero/shared": "0.22.5",
+		"@d-zero/shared": "0.23.0",
 		"ansi-colors": "4.1.3",
 		"character-entities": "2.0.2",
 		"fast-glob": "3.3.3",

--- a/packages/kamado/package.json
+++ b/packages/kamado/package.json
@@ -22,6 +22,9 @@
 		"./path": "./dist/path/path.js",
 		"./utils/dom": "./dist/utils/dom.js"
 	},
+	"engines": {
+		"node": ">=24.11.0"
+	},
 	"scripts": {
 		"build": "tsc --project tsconfig.build.json",
 		"dev": "tsc --watch --project tsconfig.build.json"
@@ -32,7 +35,7 @@
 	"dependencies": {
 		"@d-zero/dealer": "1.10.4",
 		"@d-zero/roar": "2.2.0",
-		"@d-zero/shared": "0.22.5",
+		"@d-zero/shared": "0.23.0",
 		"@hono/node-server": "2.1.0",
 		"ansi-colors": "4.1.3",
 		"character-entities": "2.0.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,10 @@
 {
 	"extends": ["@d-zero/tsconfig"],
+	"compilerOptions": {
+		// @d-zero/tsconfig only raises `lib` to ESNext; `target` still inherits
+		// es2024 from @tsconfig/node-lts. Override to ESNext so `using`/
+		// `await using` emit natively (no downlevel helpers) on Node >=24.11.
+		"target": "ESNext"
+	},
 	"exclude": ["node_modules", "**/*.js", "**/*.mjs", "**/*.cjs", "**/*.d.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1071,6 +1071,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@d-zero/shared@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@d-zero/shared@npm:0.23.0"
+  dependencies:
+    "@holiday-jp/holiday_jp": "npm:2.5.1"
+    await-event-emitter: "npm:2.0.2"
+    dayjs: "npm:1.11.21"
+    escape-string-regexp: "npm:5.0.0"
+    front-matter: "npm:4.0.2"
+    micromatch: "npm:4.0.8"
+    sanitize-filename: "npm:1.6.4"
+  checksum: 10c0/56a4e76c117d5918a2a0dfa34daf75138812db1349217d89cf65ee329ab2f2f7a9be4c9241a80fcc8ab732254f233b0381776e8fa4e4e9b96e630bba5d2ccd55
+  languageName: node
+  linkType: hard
+
 "@d-zero/textlint-config@npm:5.1.0":
   version: 5.1.0
   resolution: "@d-zero/textlint-config@npm:5.1.0"
@@ -2111,7 +2126,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@kamado-io/page-compiler@workspace:packages/@kamado-io/page-compiler"
   dependencies:
-    "@d-zero/shared": "npm:0.22.5"
+    "@d-zero/shared": "npm:0.23.0"
     "@types/html-minifier-terser": "npm:7.0.2"
     ansi-colors: "npm:4.1.3"
     character-entities: "npm:2.0.2"
@@ -8555,7 +8570,7 @@ __metadata:
   dependencies:
     "@d-zero/dealer": "npm:1.10.4"
     "@d-zero/roar": "npm:2.2.0"
-    "@d-zero/shared": "npm:0.22.5"
+    "@d-zero/shared": "npm:0.23.0"
     "@hono/node-server": "npm:2.1.0"
     "@types/node": "npm:24.13.3"
     "@types/picomatch": "npm:4.0.3"


### PR DESCRIPTION
## 概要

Explicit Resource Management（`using` / `Symbol.dispose`）導入の基盤整備のみを行います。実際の `using` 適用は今回のスコープ外です。

- root `tsconfig.json` の `target` を `ESNext` に明示的に上書き
  - `@d-zero/tsconfig` は `lib` のみ ESNext にしており、`target` は `@tsconfig/node-lts` 由来の `es2024` を継承したままだったため、`using`/`await using` をネイティブ emit（downlevel ヘルパーなし）するために上書きが必要
- `@d-zero/shared` を `0.22.5` → `0.23.0` に更新（`kamado`, `page-compiler`）
  - `0.23.0` で ERM ヘルパー（`mkdtempDisposable`, `disposableListener`）が追加され、`engines.node >= 24.11.0` が要求されるようになったため
  - この要求に合わせて、両パッケージの `package.json` に `engines.node >= 24.11.0` を追加

## 変更理由・スコープ判断の経緯

当初は `@d-zero/tools` という依存追加や、class ベースの `Symbol.dispose` 導入、`try/finally` の広範な `using` 化を想定していましたが、調査の結果:

- `@d-zero/tools` という npm パッケージは存在せず、ERM ヘルパーは `@d-zero/shared`（tools リポジトリが公開）にありました
- kamado には class 定義が1つも存在せず、本番コードに dispose 対象の実リソース（FileHandle・AbortController・Worker・child_process・stream・timer）もありませんでした
- `using` の実際の適用先はテストコードの `mkdtemp`/`vi.spyOn` パターンのみでしたが、プロダクトに直接寄与しないためスコープ外としました

そのため、今回は将来 `using` を使う際の土台（tsconfig・依存バージョン）を整えるところまでに留めています。

## 動作確認

- `yarn build`（全6パッケージ）: 成功
- `yarn test`（513テスト）: 全てパス
- `yarn lint`: エラーなし（既存警告5件のみ、本PRとは無関係）

## 補足（このリポジトリ固有の環境問題）

このセッションの作業環境（git worktree）では、`yarn build` が Lerna(Nx) 経由だと成功と報告されつつ実際には `dist` が生成されない事象がありました。`NX_WORKSPACE_ROOT_PATH=<worktree のパス> yarn build` で正しく動作することを確認済みです（本PRの変更内容とは無関係な、worktree環境特有の既知事象）。
