### PR TITLE
chore(repo): upgrade dev and CI environments to Node 26

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,13 +24,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Corepack
+        run: npm install -g corepack
+
       - name: Enable Corepack
         run: corepack enable
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: 24.19.0
+          node-version: 26.7.0
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os:
           - macOS-latest
-        node: [24]
+        node: [26]
 
     runs-on: ${{ matrix.os }}
 
@@ -27,6 +27,7 @@ jobs:
 
       - name: Enable Corepack and setup Yarn v4
         run: |
+          npm install -g corepack
           corepack enable
           yarn --version
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 	},
 	"packageManager": "yarn@4.18.0",
 	"volta": {
-		"node": "24.19.0",
+		"node": "26.7.0",
 		"yarn": "4.18.0"
 	}
 }


### PR DESCRIPTION
## Summary

- 開発環境（Volta固定のNode）とCIワークフロー（test/publish）をNode 26.7.0に更新
- Node 26はcorepackを同梱しなくなったため、各ワークフローで `corepack enable` の前に `npm install -g corepack` を明示実行
- `packages/@kamado-io/jsx-compiler` の `engines.node`（公開パッケージの最低要求バージョン）は変更なし。開発・CI用のツールチェーンバージョンとは別物のため

参考: [d-zero-dev/nitpicker#306](https://github.com/d-zero-dev/nitpicker/pull/306)

## Test plan

- [x] Node 26.7.0環境で `yarn build` が成功
- [x] Node 26.7.0環境で `yarn test` が成功（44ファイル / 513テスト全通過）
- [x] Node 26.7.0環境で `yarn lint:check` がエラー0（既存warning 5件のみ、本変更と無関係）
- [ ] CI green（test / publish 両ワークフロー）
