### PR TITLE
chore(github): auto-approve renovate and dependabot pull requests

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,18 @@
+name: Auto-approve dependency PRs
+
+on:
+  pull_request_target:
+    branches:
+      - dev
+
+permissions:
+  pull-requests: write
+
+jobs:
+  auto-approve:
+    if: github.actor == 'renovate[bot]' || github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 背景

PR #215 が stability-days クリア後も承認待ちのまま静かに滞留していた事象の調査から着手。

`renovate.json` の `autoApprove: true` は、GitHubの仕様（PR作成者は自分のPRを承認できない）により実質機能していません。そのため Renovate/Dependabot の PR は人間の手動承認に頼っており、承認後に Renovate が追加コミット（stability-days クリア後の再push等）を行うと `dismiss_stale_reviews` により承認が取り消され、CI が全部緑のまま承認待ちで静かに滞留していました（#211, #212, #162, #177 も同様の理由で滞留を確認）。

## 変更内容

- `renovate[bot]` / `dependabot[bot]` が作成した PR にのみ、`github-actions[bot]`（Renovate自身とは別アクター）が自動で `APPROVE` レビューを行う workflow を追加
- automerge を実行するかどうかの判断は従来通り Renovate の `packageRules`（minor/patch/pin/digest のみ）が握るため、この変更は「レビュー必須」の関門を機械的に通すだけで、マージ挙動自体は変えない

## 補足（別件・本PR範囲外）

`dev` ブランチ保護の必須ステータスチェック名が `test (macOS-latest, 24)` のまま古くなっており（実際の `test.yml` は Node 26）、対象コミットのチェックが永久に満たされないバグが判明。応急処置として `test (macOS-latest, 26)` に更新済み。恒久的には CI ワークフロー側の Node バージョン変更時にブランチ保護設定も追従させる運用が必要。

## 動作確認

- ワークフロー構文は既存の `test.yml` 等に倣った形式
- 実際の動作は次回 Renovate/Dependabot PR 作成時に確認
